### PR TITLE
fix: remove CLAUDE.md from version check scripts

### DIFF
--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -57,8 +57,8 @@ for (const check of JSON_CHECKS) {
 // ── Text files (extraction-pattern check) ──
 // Each entry has a regex that extracts ONLY the declared version (capture group 1),
 // not historical references like "v0.6.0 起支持".
+// Note: CLAUDE.md is intentionally gitignored (project-local AI instructions).
 const TEXT_CHECKS = [
-  { file: 'CLAUDE.md',              extract: /Current version: `(\d+\.\d+\.\d+)`\./ },
   { file: 'README.md',              extract: /当前版本：`v(\d+\.\d+\.\d+)`/ },
   { file: 'INSTALL.md',             extract: /当前发布版本：\*\*v(\d+\.\d+\.\d+)\*\*/ },
   { file: 'docs/README_en.md',      extract: /Current: `v(\d+\.\d+\.\d+)`/ },

--- a/scripts/lib/cmd-version.mjs
+++ b/scripts/lib/cmd-version.mjs
@@ -17,8 +17,8 @@ const MANIFESTS = [
 ];
 
 // ── Text files with regex patterns (first capture group = version to replace) ──
+// Note: CLAUDE.md is intentionally gitignored (project-local AI instructions).
 const TEXT_FILES = [
-  { file: 'CLAUDE.md',              pattern: /(Current version: `)0\.\d+\.\d+(`\.)/g,            replacement: '$10.%MINOR%.%PATCH%$2' },
   { file: 'README.md',              pattern: /(当前版本：`v?)0\.\d+\.\d+(`?)/g,                   replacement: '$10.%MINOR%.%PATCH%$2' },
   { file: 'INSTALL.md',             pattern: /(当前发布版本：\*\*v)0\.\d+\.\d+(\*\*)/g,            replacement: '$10.%MINOR%.%PATCH%$2' },
   { file: 'docs/README_en.md',      pattern: /(Current: `v)0\.\d+\.\d+(`)/g,                     replacement: '$10.%MINOR%.%PATCH%$2' },


### PR DESCRIPTION
CLAUDE.md is intentionally gitignored (project-local AI instructions), so the version consistency check scripts should not expect it to exist. This was causing the release CI job to fail.