### PR TITLE
v0.8.8: Token 效率优化 — prompt/skill 压缩 -60% token

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.8.7 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.8 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.8.7"
+    "version": "0.8.8"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.8.7"
+    "version": "0.8.8"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to `spec-superflow` will be documented in this file.
 
 The format loosely follows Keep a Changelog.
 
+## [0.8.8] - 2026-07-03
+
+### Changed
+
+- **Token efficiency optimization**: Compressed all prompt injection surfaces by 60.3% (from ~24,387 estimated tokens to ~9,669).
+  - `hooks/session-start`: 23→15 lines, comments compressed, platform branches share message variable.
+  - 9 skill SKILL.md files: 2,461→750 lines total (−69.5%). Each skill ≤250 lines, 0 token lint issues.
+  - Phase guard files (`.claude/always/phase-guard.md`, `GEMINI.md`): 14→3 lines each, reference state machine instead of enumerating operations.
+  - `workflow-start` initialization simplified: deferred non-critical checks to target skills.
+
+### Added
+
+- **Token baseline tool** (`scripts/token-baseline.mjs`): Measures lines, characters, and estimated tokens for all injection components. Supports `--compare` for pre/post compression analysis.
+- **Token lint rules** (`scripts/lint/rules/token-rules.mjs`): 4 rules — max lines, max chars, emphasis marker limits, code block length limits. Banned markers: `EXTREMELY_IMPORTANT`, `CRITICAL`.
+- **`--include token`** support in `lint-skills.mjs` for token-specific linting.
+- **CI token lint step**: Warning-only check in both build-and-test and release jobs.
+- **Phase guard files** now included in version consistency checks.
+
 ## [0.8.7] - 2026-07-03
 
 ### Added

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.8.7 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.8 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.8.7**。
+当前发布版本：**v0.8.8**。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v0.8.7`
+- 当前版本：`v0.8.8`
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -100,7 +100,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.8.7`
+- Current: `v0.8.8`
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)
 - Changelog: [CHANGELOG.md](../CHANGELOG.md)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.8.7: conditional injection — detects artifacts, injects workflow-start pointer
+# v0.8.8: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Three platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, Gemini CLI, Copilot CLI, Codex, OpenCode, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.8.7.
+Current version: v0.8.8.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/scripts/check-version-consistency.mjs
+++ b/scripts/check-version-consistency.mjs
@@ -64,6 +64,8 @@ const TEXT_CHECKS = [
   { file: 'docs/README_en.md',      extract: /Current: `v(\d+\.\d+\.\d+)`/ },
   { file: 'hooks/session-start',    extract: /# v(\d+\.\d+\.\d+): conditional injection/ },
   { file: 'llms.txt',               extract: /Current version: v(\d+\.\d+\.\d+)\./ },
+  { file: '.claude/always/phase-guard.md', extract: /# spec-superflow v(\d+\.\d+\.\d+) \|/ },
+  { file: 'GEMINI.md',              extract: /# spec-superflow v(\d+\.\d+\.\d+) \|/ },
 ];
 
 for (const check of TEXT_CHECKS) {

--- a/scripts/lib/cmd-version.mjs
+++ b/scripts/lib/cmd-version.mjs
@@ -24,8 +24,8 @@ const TEXT_FILES = [
   { file: 'docs/README_en.md',      pattern: /(Current: `v)0\.\d+\.\d+(`)/g,                     replacement: '$10.%MINOR%.%PATCH%$2' },
   { file: 'hooks/session-start',    pattern: /(# v)0\.\d+\.\d+(: conditional injection)/g,       replacement: '$10.%MINOR%.%PATCH%$2' },
   { file: 'llms.txt',               pattern: /(Current version: v)0\.\d+\.\d+(\.)/g,             replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: '.claude/always/phase-guard.md', pattern: /(# Phase Guard: v)0\.\d+\.\d+(\n?)/g,       replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: 'GEMINI.md',              pattern: /(\*\*版本\*\*: v)0\.\d+\.\d+/g,                    replacement: '$10.%MINOR%.%PATCH%' },
+  { file: '.claude/always/phase-guard.md', pattern: /(# spec-superflow v)0\.\d+\.\d+( \|)/g,      replacement: '$10.%MINOR%.%PATCH%$2' },
+  { file: 'GEMINI.md',              pattern: /(# spec-superflow v)0\.\d+\.\d+( \|)/g,              replacement: '$10.%MINOR%.%PATCH%$2' },
 ];
 
 function getNestedValue(obj, pathParts) {


### PR DESCRIPTION
## v0.8.8

### Changed
- **Token efficiency**: Compressed all prompt injection surfaces by **60.3%** (~24,387 → ~9,669 tokens)
- 9 skill SKILL.md: 2,461 → 750 lines (−69.5%)
- Phase guard: 14 → 3 lines, reference state machine
- `hooks/session-start`: comments compressed, platform branches share variable

### Added
- `token-baseline.mjs` — measurement tool with `--compare` support
- `token-rules.mjs` — 4 lint rules (max lines, max chars, emphasis, code blocks)
- `--include token` in lint-skills.mjs
- CI token lint step (warning only)
- Phase guard + GEMINI.md in version consistency checks

### Fixed
- `cmd-version.mjs` patterns updated for compressed phase guard format
- Phase guard version auto-sync restored

### Verification
- 212 tests pass
- Doctor: all checks pass
- Zero token lint issues