### PR TITLE
Fix DP-0 audit recording

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.8.10 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.11 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.8.10"
+    "version": "0.8.11"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.8.10"
+    "version": "0.8.11"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `spec-superflow` will be documented in this file.
 
 The format loosely follows Keep a Changelog.
 
+## [0.8.11] - 2026-07-06
+
+### Fixed
+
+- **DP-0 audit consistency** — `ssf audit` now treats existing `dp_0_confirmed: true` state as a recorded DP-0 confirmation, and `dp_0_result` is now persisted by the state loader instead of being dropped after `ssf state set`.
+
 ## [0.8.10] - 2026-07-06
 
 ### Fixed

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.8.10 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.11 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.8.10**。
+当前发布版本：**v0.8.11**。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v0.8.10`
+- 当前版本：`v0.8.11`
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -119,7 +119,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.8.10`
+- Current: `v0.8.11`
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)
 - Changelog: [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/showcase.html
+++ b/docs/showcase.html
@@ -690,7 +690,7 @@
 
 <footer>
   <div class="container">
-    spec-superflow v0.8.10 &middot; MIT License &middot;
+    spec-superflow v0.8.11 &middot; MIT License &middot;
     <a href="https://github.com/MageByte-Zero/spec-superflow" target="_blank">github.com/MageByte-Zero/spec-superflow</a>
   </div>
 </footer>

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.8.10: conditional injection — detects artifacts, injects workflow-start pointer
+# v0.8.11: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Three platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.8.10.
+Current version: v0.8.11.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/scripts/lib/cmd-audit.mjs
+++ b/scripts/lib/cmd-audit.mjs
@@ -26,10 +26,22 @@ function formatTimestamp(ts) {
   return String(ts);
 }
 
+function isConfirmed(value) {
+  return value === true || value === 'true';
+}
+
+function formatDpResult(state, dp) {
+  const result = formatResult(state[`dp_${dp}_result`]);
+  if (dp === 0 && result === 'not recorded' && isConfirmed(state.dp_0_confirmed)) {
+    return 'confirmed';
+  }
+  return result;
+}
+
 function generateReport(changeDir, state) {
   const rows = [];
   for (let i = 0; i <= 7; i++) {
-    const result = formatResult(state[`dp_${i}_result`]);
+    const result = formatDpResult(state, i);
     const timestamp = formatTimestamp(state[`dp_${i}_timestamp`]);
     rows.push({ dp: i, name: DP_NAMES[i], result, timestamp });
   }

--- a/scripts/lib/state-loader.mjs
+++ b/scripts/lib/state-loader.mjs
@@ -17,6 +17,7 @@ const BUILTIN_DEFAULTS = {
   last_transition_from: null,
   last_transition_to: null,
   dp_0_decisions: null,
+  dp_0_result: null,
   dp_0_confirmed: null,
   dp_0_timestamp: null,
   dp_1_result: null,
@@ -80,6 +81,7 @@ export function writeState(changeDir, state) {
   lines.push('');
   lines.push('# === Decision points ===');
   lines.push(`dp_0_decisions: ${state.dp_0_decisions ?? 'null'}`);
+  lines.push(`dp_0_result: ${state.dp_0_result ?? 'null'}`);
   lines.push(`dp_0_confirmed: ${state.dp_0_confirmed ?? 'null'}`);
   lines.push(`dp_0_timestamp: ${state.dp_0_timestamp ?? 'null'}`);
   lines.push(`dp_1_result: ${state.dp_1_result ?? 'null'}`);

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -31,6 +31,7 @@ Ask: change name + one-sentence intent, known constraints, related optimizations
 After confirmation:
 ```bash
 ssf state set <change-dir> dp_0_decisions "<summary>"
+ssf state set <change-dir> dp_0_result confirmed
 ssf state set <change-dir> dp_0_confirmed true
 ssf state set <change-dir> dp_0_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```

--- a/tests/lib/cmd-audit.test.mjs
+++ b/tests/lib/cmd-audit.test.mjs
@@ -69,6 +69,24 @@ describe('cmd-audit: generateReport()', () => {
     assert.ok(report.includes('6/8 未记录'), `Expected 6/8 missing but got: ${report}`);
   });
 
+  it('treats confirmed DP-0 state as recorded without dp_0_result', () => {
+    const state = {
+      change_name: 'test',
+      state: 'specifying',
+      dp_0_decisions: 'scope confirmed',
+      dp_0_confirmed: 'true',
+      dp_0_timestamp: '2026-07-06T10:50:00Z',
+    };
+
+    const report = generateReport(tempDir, state);
+
+    assert.ok(
+      report.includes('| DP-0 | 用户确认门禁 | confirmed | 2026-07-06T10:50:00Z |'),
+      `Expected DP-0 to be recorded from dp_0_confirmed but got: ${report}`,
+    );
+    assert.ok(report.includes('1/8 已记录'), `Expected 1/8 recorded but got: ${report}`);
+  });
+
   it('marks unrecorded DPs with interpretation hint', () => {
     const state = {
       change_name: 'test',

--- a/tests/lib/state-loader.test.mjs
+++ b/tests/lib/state-loader.test.mjs
@@ -152,8 +152,8 @@ describe('state-loader: writeState()', () => {
   it('writes all DP fields (0-7)', () => {
     const state = {
       state: 'closing',
-      // DP-0 uses different fields (decisions + confirmed, not result)
       dp_0_decisions: 'scope: csv export only, tech: nestjs',
+      dp_0_result: 'confirmed: scope ok',
       dp_0_confirmed: 'true',
       dp_0_timestamp: '2026-07-01T08:00:00Z',
       dp_1_result: 'confirmed: csv export',
@@ -169,9 +169,26 @@ describe('state-loader: writeState()', () => {
 
     const content = readFileSync(join(tempDir, '.spec-superflow.yaml'), 'utf-8');
     assert.ok(content.includes('dp_0_decisions: scope: csv export only, tech: nestjs'));
+    assert.ok(content.includes('dp_0_result: confirmed: scope ok'));
     assert.ok(content.includes('dp_0_confirmed: true'));
     assert.ok(content.includes('dp_1_result: confirmed: csv export'));
     assert.ok(content.includes('dp_5_result: null'));
+  });
+
+  it('round-trips dp_0_result when updated through state loader', () => {
+    stateLoader.writeState(tempDir, {
+      state: 'exploring',
+      dp_0_decisions: 'scope confirmed',
+      dp_0_confirmed: 'true',
+    });
+
+    stateLoader.updateField(tempDir, 'dp_0_result', 'confirmed: manual');
+
+    const content = readFileSync(join(tempDir, '.spec-superflow.yaml'), 'utf-8');
+    const state = stateLoader.readState(tempDir);
+
+    assert.ok(content.includes('dp_0_result: confirmed: manual'));
+    assert.equal(state.dp_0_result, 'confirmed: manual');
   });
 
   it('round-trips state through write then read', () => {


### PR DESCRIPTION
## Summary

- Fix `ssf audit` so DP-0 is counted as recorded when existing state has `dp_0_confirmed: true` but no `dp_0_result`.
- Persist `dp_0_result` in the state loader so `ssf state set <change-dir> dp_0_result ...` no longer reports success while dropping the field.
- Update `workflow-start` DP-0 instructions and prepare the `0.8.11` patch release.

## Root Cause

DP-0 used a different state shape from the other decision points. `workflow-start` wrote `dp_0_decisions`, `dp_0_confirmed`, and `dp_0_timestamp`, while `ssf audit` only read `dp_0_result`. The state loader also did not write `dp_0_result`, so manual CLI updates were lost on writeback.

## Verification

- `node --test tests/lib/cmd-audit.test.mjs`
- `node --test tests/lib/state-loader.test.mjs`
- CLI repro for issue #18 using a temporary `.spec-superflow.yaml`
- `npm run build`
- `npm test`
- `node scripts/spec-superflow.mjs doctor`
- `node scripts/check-version-consistency.mjs`

Fixes #18
