### PR TITLE
Fix workflow inference for non-JS source files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.8.11 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.12 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.8.11"
+    "version": "0.8.12"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.8.11"
+    "version": "0.8.12"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `spec-superflow` will be documented in this file.
 
 The format loosely follows Keep a Changelog.
 
+## [0.8.12] - 2026-07-06
+
+### Fixed
+
+- **Workflow mode inference** — hotfix/tweak auto-detection now recognizes common non-JavaScript source files, including Java, Go, Python, Rust, Kotlin, Swift, C/C++, C#, Ruby, PHP, and shell scripts, so multi-task code changes are no longer misclassified as config/doc-only tweaks.
+
 ## [0.8.11] - 2026-07-06
 
 ### Fixed

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.8.11 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.12 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.8.11**。
+当前发布版本：**v0.8.12**。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v0.8.11`
+- 当前版本：`v0.8.12`
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -119,7 +119,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.8.11`
+- Current: `v0.8.12`
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)
 - Changelog: [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/showcase.html
+++ b/docs/showcase.html
@@ -690,7 +690,7 @@
 
 <footer>
   <div class="container">
-    spec-superflow v0.8.11 &middot; MIT License &middot;
+    spec-superflow v0.8.12 &middot; MIT License &middot;
     <a href="https://github.com/MageByte-Zero/spec-superflow" target="_blank">github.com/MageByte-Zero/spec-superflow</a>
   </div>
 </footer>

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.8.11: conditional injection — detects artifacts, injects workflow-start pointer
+# v0.8.12: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Three platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.8.11.
+Current version: v0.8.12.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "0.8.11",
+      "version": "0.8.12",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/scripts/infer-workflow.mjs
+++ b/scripts/infer-workflow.mjs
@@ -4,15 +4,26 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { readState } from './lib/state-loader.mjs';
 
-const CODE_EXTS = new Set([
+const CODE_EXTS = [
   'mjs', 'js', 'ts', 'jsx', 'tsx', 'cjs',
-]);
-const CONFIG_DOC_EXTS = new Set([
+  'java', 'go', 'py', 'pyw', 'rb', 'php',
+  'rs', 'kt', 'kts', 'swift',
+  'c', 'h', 'cc', 'cpp', 'cxx', 'hpp',
+  'cs', 'fs', 'fsx', 'vb',
+  'scala', 'sc', 'clj', 'cljs', 'ex', 'exs',
+  'dart', 'lua', 'r', 'pl', 'pm', 'sh', 'bash', 'zsh', 'fish',
+];
+const CONFIG_DOC_EXTS = [
   'md', 'json', 'yaml', 'yml', 'toml', 'ini',
   'txt', 'html', 'css',
-]);
+];
+const CODE_EXT_SET = new Set(CODE_EXTS);
+const CONFIG_DOC_EXT_SET = new Set(CONFIG_DOC_EXTS);
+const FILE_EXT_PATTERN = [...CODE_EXTS, ...CONFIG_DOC_EXTS]
+  .sort((a, b) => b.length - a.length)
+  .join('|');
 
-const FILE_RE = /\b\/?(?:[\w-]+\/)*[\w-]+\.(mjs|js|ts|jsx|tsx|cjs|md|json|yaml|yml|toml|ini|txt|html|css)\b/gi;
+const FILE_RE = new RegExp(`\\b/?(?:[\\w-]+/)*[\\w-]+\\.(${FILE_EXT_PATTERN})\\b`, 'gi');
 
 function readText(dir, name) {
   const p = join(dir, name);
@@ -69,8 +80,8 @@ function inferMode(changeDir) {
     const parts = f.split('.');
     return parts[parts.length - 1].toLowerCase();
   });
-  const codeFileCount = allExts.filter(e => CODE_EXTS.has(e)).length;
-  const configDocOnly = codeFileCount === 0 && allExts.every(e => CONFIG_DOC_EXTS.has(e));
+  const codeFileCount = allExts.filter(e => CODE_EXT_SET.has(e)).length;
+  const configDocOnly = codeFileCount === 0 && allExts.every(e => CONFIG_DOC_EXT_SET.has(e));
 
   // No artifacts → safe default to full
   if (taskCount === 0 && fileCount === 0) {

--- a/tests/lib/infer-workflow.test.mjs
+++ b/tests/lib/infer-workflow.test.mjs
@@ -63,6 +63,47 @@ describe('infer-workflow: inferMode()', () => {
     assert.equal(result.mode, 'hotfix', `Expected hotfix but got ${result.mode}: ${result.reason}`);
   });
 
+  it('infers hotfix for small Java code changes', () => {
+    const changeDir = mkdtempSync(join(tempDir, 'java-hotfix-'));
+    writeFileSync(join(changeDir, '.spec-superflow.yaml'), 'state: exploring\nworkflow: auto');
+    writeFileSync(join(changeDir, 'proposal.md'), '# Proposal\nFix null check in src/Main.java');
+    writeFileSync(join(changeDir, 'tasks.md'), '- [ ] Fix null check in src/Main.java\n- [ ] Add regression test');
+
+    const result = inferMode(changeDir);
+
+    assert.equal(result.mode, 'hotfix', `Expected hotfix but got ${result.mode}: ${result.reason}`);
+  });
+
+  it('does not infer tweak for multi-task Java and Go code changes', () => {
+    const javaDir = mkdtempSync(join(tempDir, 'java-code-'));
+    writeFileSync(join(javaDir, '.spec-superflow.yaml'), 'state: exploring\nworkflow: auto');
+    writeFileSync(join(javaDir, 'proposal.md'), '# Proposal\nRefactor service in src/Main.java');
+    writeFileSync(join(javaDir, 'tasks.md'), '- [ ] Update service in src/Main.java\n- [ ] Add unit test\n- [ ] Update integration test');
+
+    const goDir = mkdtempSync(join(tempDir, 'go-code-'));
+    writeFileSync(join(goDir, '.spec-superflow.yaml'), 'state: exploring\nworkflow: auto');
+    writeFileSync(join(goDir, 'proposal.md'), '# Proposal\nRefactor handler in cmd/server/main.go');
+    writeFileSync(join(goDir, 'tasks.md'), '- [ ] Update handler in cmd/server/main.go\n- [ ] Add unit test\n- [ ] Update wiring');
+
+    assert.equal(inferMode(javaDir).mode, 'full');
+    assert.equal(inferMode(goDir).mode, 'full');
+  });
+
+  it('does not infer tweak for multi-task Python and Rust code changes', () => {
+    const pythonDir = mkdtempSync(join(tempDir, 'python-code-'));
+    writeFileSync(join(pythonDir, '.spec-superflow.yaml'), 'state: exploring\nworkflow: auto');
+    writeFileSync(join(pythonDir, 'proposal.md'), '# Proposal\nRefactor worker in app/worker.py');
+    writeFileSync(join(pythonDir, 'tasks.md'), '- [ ] Update worker in app/worker.py\n- [ ] Add unit test\n- [ ] Update scheduler');
+
+    const rustDir = mkdtempSync(join(tempDir, 'rust-code-'));
+    writeFileSync(join(rustDir, '.spec-superflow.yaml'), 'state: exploring\nworkflow: auto');
+    writeFileSync(join(rustDir, 'proposal.md'), '# Proposal\nRefactor parser in src/parser.rs');
+    writeFileSync(join(rustDir, 'tasks.md'), '- [ ] Update parser in src/parser.rs\n- [ ] Add unit test\n- [ ] Update caller');
+
+    assert.equal(inferMode(pythonDir).mode, 'full');
+    assert.equal(inferMode(rustDir).mode, 'full');
+  });
+
   it('infers tweak for config/doc-only change (≤4 tasks)', () => {
     writeFileSync(join(tempDir, '.spec-superflow.yaml'), 'state: exploring\nworkflow: auto');
     writeFileSync(join(tempDir, 'proposal.md'), '# Proposal\nUpdate README.md');


### PR DESCRIPTION
## Summary

- Expand workflow auto-detection so common non-JavaScript source files are recognized as code files.
- Prevent multi-task Java, Go, Python, Rust, and similar code changes from being misclassified as config/doc-only `tweak` work.
- Prepare the `0.8.12` patch release.

## Root Cause

`infer-workflow.mjs` only recognized JavaScript/TypeScript extensions as code files, and its file-matching regex used the same narrow extension set. Paths like `src/Main.java`, `cmd/server/main.go`, `app/worker.py`, and `src/parser.rs` were ignored by file collection, so multi-task code changes could fall through into the `tweak` path.

## Verification

- `node --test tests/lib/infer-workflow.test.mjs`
- CLI repro for a 3-task Go change now returns `full`
- `npm run build`
- `npm test`
- `node scripts/spec-superflow.mjs doctor`
- `node scripts/check-version-consistency.mjs`

Fixes #19
