### PR TITLE
[codex] fix Codex hooks manifest

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -22,7 +22,7 @@
     "codex"
   ],
   "skills": "./skills/",
-  "hooks": {},
+  "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "spec-superflow",
     "shortDescription": "Spec-first workflow with guarded execution.",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "spec-superflow session start hook - injects workflow-start as session context",
   "hooks": {
     "SessionStart": [
       {

--- a/scripts/lib/cmd-doctor.mjs
+++ b/scripts/lib/cmd-doctor.mjs
@@ -52,6 +52,10 @@ function checkHooks(root) {
   }
   try {
     const hooks = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+    const keys = Object.keys(hooks);
+    if (keys.length !== 1 || keys[0] !== 'hooks') {
+      return { pass: false, message: `invalid top-level keys (${keys.join(', ') || 'none'})` };
+    }
     if (hooks.hooks && typeof hooks.hooks === 'object' && !Array.isArray(hooks.hooks)) {
       return { pass: true, message: 'valid format' };
     }
@@ -67,16 +71,16 @@ function checkCodexManifest(root) {
   if (!manifest) {
     return { pass: false, message: '.codex-plugin/plugin.json not found' };
   }
-  if (JSON.stringify(manifest.hooks) !== '{}') {
+  if (manifest.hooks !== './hooks/hooks.json') {
     return {
       pass: false,
-      message: 'Codex manifest must set hooks to {} to suppress hooks/hooks.json auto-discovery',
+      message: 'Codex manifest must set hooks to ./hooks/hooks.json',
     };
   }
   if (manifest.interface?.category !== 'Developer Tools') {
     return { pass: false, message: 'Codex category should be Developer Tools' };
   }
-  return { pass: true, message: 'hooks suppressed, category Developer Tools' };
+  return { pass: true, message: 'hooks wired, category Developer Tools' };
 }
 
 function checkSkills(root) {

--- a/tests/lib/cmd-doctor.test.mjs
+++ b/tests/lib/cmd-doctor.test.mjs
@@ -98,6 +98,18 @@ describe('cmd-doctor: checkHooks()', () => {
     assert.equal(result.pass, true);
   });
 
+  it('fails when hooks.json contains extra top-level keys', () => {
+    mkdirSync(join(tempDir, 'hooks'), { recursive: true });
+    writeFileSync(join(tempDir, 'hooks', 'hooks.json'), JSON.stringify({
+      description: 'extra metadata',
+      hooks: { SessionStart: [{ command: 'bash hooks/session-start' }] },
+    }));
+
+    const result = checkHooks(tempDir);
+    assert.equal(result.pass, false);
+    assert.ok(result.message.includes('invalid top-level keys'));
+  });
+
   it('fails when hooks.json has array format (legacy)', () => {
     writeFileSync(join(tempDir, 'hooks', 'hooks.json'), JSON.stringify({
       hooks: [{ event: 'SessionStart', command: 'bash hooks/session-start' }],
@@ -137,7 +149,7 @@ describe('cmd-doctor: checkCodexManifest()', () => {
     assert.ok(result.message.includes('not found'));
   });
 
-  it('fails when hooks is absent because Codex auto-discovers hooks/hooks.json', () => {
+  it('fails when hooks is absent', () => {
     mkdirSync(join(tempDir, '.codex-plugin'), { recursive: true });
     writeFileSync(join(tempDir, '.codex-plugin', 'plugin.json'), JSON.stringify({
       interface: { category: 'Developer Tools' },
@@ -145,12 +157,12 @@ describe('cmd-doctor: checkCodexManifest()', () => {
 
     const result = checkCodexManifest(tempDir);
     assert.equal(result.pass, false);
-    assert.ok(result.message.includes('hooks to {}'));
+    assert.ok(result.message.includes('hooks to ./hooks/hooks.json'));
   });
 
   it('fails when category is not Developer Tools', () => {
     writeFileSync(join(tempDir, '.codex-plugin', 'plugin.json'), JSON.stringify({
-      hooks: {},
+      hooks: './hooks/hooks.json',
       interface: { category: 'Productivity' },
     }));
 
@@ -159,9 +171,9 @@ describe('cmd-doctor: checkCodexManifest()', () => {
     assert.ok(result.message.includes('Developer Tools'));
   });
 
-  it('passes when hooks are explicitly suppressed and category is Developer Tools', () => {
+  it('passes when hooks are wired and category is Developer Tools', () => {
     writeFileSync(join(tempDir, '.codex-plugin', 'plugin.json'), JSON.stringify({
-      hooks: {},
+      hooks: './hooks/hooks.json',
       interface: { category: 'Developer Tools' },
     }));
 


### PR DESCRIPTION
## What changed
- wire the Codex plugin manifest to `./hooks/hooks.json` instead of suppressing hooks
- remove the unsupported top-level `description` field from `hooks/hooks.json`
- update `ssf doctor` to catch both misconfigurations before release
- add regression coverage for the Codex manifest and hooks JSON shape

## Why
Codex currently fails to load the plugin's session hook because the manifest does not point to the hooks file, and the hooks file includes an unsupported top-level field. That leaves marketplace installs without the advertised automatic SessionStart context injection.

## Impact
Codex marketplace installs can load the `SessionStart` hook without local patching, and future releases are less likely to regress because `ssf doctor` and its tests now enforce the expected Codex shape.

## Validation
- `node --test tests/lib/cmd-doctor.test.mjs`
