### PR TITLE
feat(platforms): expand install support to 17 platforms (v0.8.13)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.8.12",
+      "version": "0.8.13",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.8.12 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.13 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.8.12"
+    "version": "0.8.13"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.8.12"
+    "version": "0.8.13"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.8.12",
+      "version": "0.8.13",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,34 @@ jobs:
         run: node scripts/lint/lint-skills.mjs --include token
         continue-on-error: true
 
+  platform-install-smoke:
+    name: Platform Install Smoke (8 platforms)
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - name: Smoke test all 8 platform installers (--local)
+        shell: bash
+        run: |
+          set -e
+          declare -A SKILLS=( [cline]=.cline/skills [kiro]=.kiro/skills [windsurf]=.windsurf/skills [qwen]=.qwen/skills [amazon-q]=.amazonq/skills [roocode]=.roo/skills [continue]=.continue/skills [pi]=.pi/skills )
+          declare -A RULES=( [cline]=.clinerules/phase-guard.md [kiro]=.kiro/steering/phase-guard.md [windsurf]=.windsurf/rules/phase-guard.md [qwen]=.qwen/rules/phase-guard.md [amazon-q]=.amazonq/rules/phase-guard.md [roocode]=.roo/rules/phase-guard.md [continue]=.continue/rules/phase-guard.md )
+          for id in cline kiro windsurf qwen amazon-q roocode continue pi; do
+            tmp="$(mktemp -d)"
+            ( cd "$tmp" && node "$GITHUB_WORKSPACE/scripts/install-$id.mjs" --local "$GITHUB_WORKSPACE" > /dev/null )
+            [ -d "$tmp/${SKILLS[$id]}" ] || { echo "FAIL $id: skills dir missing"; exit 1; }
+            count="$(ls "$tmp/${SKILLS[$id]}" | wc -l | tr -d ' ')"
+            [ "$count" -ge 9 ] || { echo "FAIL $id: only $count skills (expected 9)"; exit 1; }
+            if [ -n "${RULES[$id]:-}" ]; then
+              [ -f "$tmp/${RULES[$id]}" ] || { echo "FAIL $id: phase-guard rule missing"; exit 1; }
+            fi
+            echo "OK $id — 9 skills, rule=${RULES[$id]:-none}"
+          done
+          echo "All 8 platform installers passed smoke test."
+
   release:
     name: Release
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to `spec-superflow` will be documented in this file.
 
 The format loosely follows Keep a Changelog.
 
+## [0.8.13] - 2026-07-06
+
+### Added
+
+- **跨平台安装支持扩展至 17 个平台** — 新增 8 个 AI 编程平台的一键安装器，平台覆盖面对齐 comet：
+  - `ssf install-cline` — Cline（`.cline/skills/` + `.clinerules/phase-guard.md`）
+  - `ssf install-kiro` — Kiro（`.kiro/skills/` + `.kiro/steering/phase-guard.md`）
+  - `ssf install-windsurf` — Windsurf（`.windsurf/skills/` + `.windsurf/rules/phase-guard.md`）
+  - `ssf install-qwen` — Qwen Code（`.qwen/skills/` + `.qwen/rules/phase-guard.md`）
+  - `ssf install-amazon-q` — Amazon Q Developer（`.amazonq/skills/` + `.amazonq/rules/phase-guard.md`）
+  - `ssf install-roocode` — Roo Code（`.roo/skills/` + `.roo/rules/phase-guard.md`）
+  - `ssf install-continue` — Continue（`.continue/skills/` + `.continue/rules/phase-guard.md`）
+  - `ssf install-pi` — Pi（`.pi/skills/`，无规则目录，手动 `/workflow-start`）
+- **共享安装器架构** — 新增 `scripts/lib/platforms.mjs`（平台注册表）与 `scripts/lib/install.mjs`（共享安装器），8 个 `install-<id>.mjs` 为薄壳调用，路径全部与 comet `src/core/platforms.ts` 交叉核实。`install-cursor.mjs` / `install-workbuddy` 保持原样。
+- **平台支持矩阵文档** — 新增 `docs/platform-matrix.md`，17 平台 × Skills/Rules/Hooks 三层接入透明化。
+- **CLI 命令** — `ssf` 注册 8 个 `install-<id>` 子命令，`npx spec-superflow@latest install-<id>` 一键部署。
+
+### Changed
+
+- INSTALL.md 平台总览表从 9 行扩至 17 行，新增 8 个平台完整安装/升级/卸载/验证章节。
+- README.md 安装区表格与 CLI 命令表同步扩充。
+
+### Notes
+
+- Kiro / Windsurf / Qwen / Amazon Q 原生支持 hooks，但 spec-superflow 的 SessionStart 钩子在这些平台的可用性未逐一验证，v0.8.13 暂不写入 hook 配置；上下文注入由 phase-guard 规则（平台自动加载）承担，后续版本验证后补齐。
+- 剩余 14 个 comet 平台（Junie / Bob / ForgeCode / Crush / iFlow / CoStrict / Factory / KiloCode / Auggie / Lingma / KimiCode / Antigravity ×2 等）留待 v0.8.14+ 分批跟进。
+
 ## [0.8.12] - 2026-07-06
 
 ### Fixed

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.8.12 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.8.13 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.8.12**。
+当前发布版本：**v0.8.13**。
 
 ---
 
@@ -24,6 +24,14 @@
 | OpenCode | plugin entry / skills 目录 | `git pull` | 删除 plugin/skills |
 | WorkBuddy | `ssf install-workbuddy` | 重新运行安装器 | 删除 marketplace 插件并禁用 |
 | Trae IDE / TRAE Work | `.trae/skills` / 上传 zip 或 .skill / marketplace | `git pull` + 重新导入 | UI 卸载或删除技能目录 |
+| Cline | `ssf install-cline` | 重新运行脚本 | 删除 `.cline/skills/`、`.clinerules/` |
+| Kiro | `ssf install-kiro` | 重新运行脚本 | 删除 `.kiro/skills/`、`.kiro/steering/` |
+| Windsurf | `ssf install-windsurf` | 重新运行脚本 | 删除 `.windsurf/skills/`、`.windsurf/rules/` |
+| Qwen Code | `ssf install-qwen` | 重新运行脚本 | 删除 `.qwen/skills/`、`.qwen/rules/` |
+| Amazon Q Developer | `ssf install-amazon-q` | 重新运行脚本 | 删除 `.amazonq/skills/`、`.amazonq/rules/` |
+| Roo Code | `ssf install-roocode` | 重新运行脚本 | 删除 `.roo/skills/`、`.roo/rules/` |
+| Continue | `ssf install-continue` | 重新运行脚本 | 删除 `.continue/skills/`、`.continue/rules/` |
+| Pi | `ssf install-pi` | 重新运行脚本 | 删除 `.pi/skills/` |
 
 ---
 
@@ -410,6 +418,199 @@ cd /path/to/spec-superflow && git pull
 ### 卸载
 
 删除客户端技能目录中的 spec-superflow 技能即可。
+
+---
+
+## Cline
+
+Cline 原生读取 `.clinerules/*.md` 作为常驻上下文。安装脚本部署 skills 到 `.cline/skills/`、运行时依赖到 `.cline/spec-superflow/`、phase-guard 规则到 `.clinerules/phase-guard.md`（Cline 自动加载，无需手动引用）。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-cline
+```
+
+或从本地仓库（开发 / 离线）：
+
+```bash
+node scripts/install-cline.mjs --local /path/to/spec-superflow
+```
+
+### 升级
+
+```bash
+npx spec-superflow@latest install-cline
+```
+
+### 卸载
+
+```bash
+rm -rf .cline/skills .cline/spec-superflow .clinerules/phase-guard.md
+```
+
+### 验证
+
+```bash
+ls .cline/skills          # 应有 9 个 skill 目录
+cat .clinerules/phase-guard.md
+```
+
+---
+
+## Kiro
+
+AWS Kiro IDE 读取 `.kiro/steering/*.md` 作为 steering 规则。安装脚本部署 skills 到 `.kiro/skills/`、运行时依赖到 `.kiro/spec-superflow/`、phase-guard 规则到 `.kiro/steering/phase-guard.md`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-kiro
+```
+
+### 升级
+
+```bash
+npx spec-superflow@latest install-kiro
+```
+
+### 卸载
+
+```bash
+rm -rf .kiro/skills .kiro/spec-superflow .kiro/steering/phase-guard.md
+```
+
+### 验证
+
+```bash
+ls .kiro/skills
+cat .kiro/steering/phase-guard.md
+```
+
+---
+
+## Windsurf
+
+Codeium Windsurf 读取 `.windsurf/rules/*.md` 作为规则。安装脚本部署 skills 到 `.windsurf/skills/`、运行时依赖到 `.windsurf/spec-superflow/`、phase-guard 规则到 `.windsurf/rules/phase-guard.md`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-windsurf
+```
+
+### 升级 / 卸载 / 验证
+
+```bash
+# 升级
+npx spec-superflow@latest install-windsurf
+# 卸载
+rm -rf .windsurf/skills .windsurf/spec-superflow .windsurf/rules/phase-guard.md
+# 验证
+ls .windsurf/skills && cat .windsurf/rules/phase-guard.md
+```
+
+---
+
+## Qwen Code
+
+Qwen Code CLI（Gemini CLI fork）读取 `.qwen/rules/*.md` 作为规则。安装脚本部署 skills 到 `.qwen/skills/`、运行时依赖到 `.qwen/spec-superflow/`、phase-guard 规则到 `.qwen/rules/phase-guard.md`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-qwen
+```
+
+### 升级 / 卸载 / 验证
+
+```bash
+npx spec-superflow@latest install-qwen
+rm -rf .qwen/skills .qwen/spec-superflow .qwen/rules/phase-guard.md
+ls .qwen/skills && cat .qwen/rules/phase-guard.md
+```
+
+---
+
+## Amazon Q Developer
+
+Amazon Q Developer CLI 读取 `.amazonq/rules/*.md` 作为规则。安装脚本部署 skills 到 `.amazonq/skills/`、运行时依赖到 `.amazonq/spec-superflow/`、phase-guard 规则到 `.amazonq/rules/phase-guard.md`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-amazon-q
+```
+
+### 升级 / 卸载 / 验证
+
+```bash
+npx spec-superflow@latest install-amazon-q
+rm -rf .amazonq/skills .amazonq/spec-superflow .amazonq/rules/phase-guard.md
+ls .amazonq/skills && cat .amazonq/rules/phase-guard.md
+```
+
+---
+
+## Roo Code
+
+Roo Code（Roo Cline）读取 `.roo/rules/*.md` 作为规则。安装脚本部署 skills 到 `.roo/skills/`、运行时依赖到 `.roo/spec-superflow/`、phase-guard 规则到 `.roo/rules/phase-guard.md`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-roocode
+```
+
+### 升级 / 卸载 / 验证
+
+```bash
+npx spec-superflow@latest install-roocode
+rm -rf .roo/skills .roo/spec-superflow .roo/rules/phase-guard.md
+ls .roo/skills && cat .roo/rules/phase-guard.md
+```
+
+---
+
+## Continue
+
+Continue（VS Code 扩展）读取 `.continue/rules/*.md` 作为规则。安装脚本部署 skills 到 `.continue/skills/`、运行时依赖到 `.continue/spec-superflow/`、phase-guard 规则到 `.continue/rules/phase-guard.md`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-continue
+```
+
+### 升级 / 卸载 / 验证
+
+```bash
+npx spec-superflow@latest install-continue
+rm -rf .continue/skills .continue/spec-superflow .continue/rules/phase-guard.md
+ls .continue/skills && cat .continue/rules/phase-guard.md
+```
+
+---
+
+## Pi
+
+Pi agent 从 `.pi/skills/`（全局 `.pi/agent/skills/`）读取技能。Pi 没有规则目录，安装脚本只部署 skills 到 `.pi/skills/`、运行时依赖到 `.pi/spec-superflow/`；启动工作流时需手动调用 `/workflow-start`。
+
+### 安装
+
+```bash
+npx spec-superflow@latest install-pi
+```
+
+### 升级 / 卸载 / 验证
+
+```bash
+npx spec-superflow@latest install-pi
+rm -rf .pi/skills .pi/spec-superflow
+ls .pi/skills   # 应有 9 个 skill 目录
+```
+
+> Pi 无 phase-guard 规则自动注入，会话中请显式 `用 workflow-start 开始`。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,23 @@ gemini extensions install https://github.com/MageByte-Zero/spec-superflow
 gemini extensions update spec-superflow   # 升级
 ```
 
-### OpenCode / WorkBuddy / Trae
+### 更多平台（Cline / Kiro / Windsurf / Qwen / Amazon Q / Roo Code / Continue / Pi / OpenCode / WorkBuddy / Trae）
 
 | 平台 | 安装方式 | 状态 |
 |------|---------|------|
+| **Cline** | `npx spec-superflow@latest install-cline` | 已提供安装器 |
+| **Kiro** | `npx spec-superflow@latest install-kiro` | 已提供安装器 |
+| **Windsurf** | `npx spec-superflow@latest install-windsurf` | 已提供安装器 |
+| **Qwen Code** | `npx spec-superflow@latest install-qwen` | 已提供安装器 |
+| **Amazon Q Developer** | `npx spec-superflow@latest install-amazon-q` | 已提供安装器 |
+| **Roo Code** | `npx spec-superflow@latest install-roocode` | 已提供安装器 |
+| **Continue** | `npx spec-superflow@latest install-continue` | 已提供安装器 |
+| **Pi** | `npx spec-superflow@latest install-pi` | 已提供安装器 |
 | **OpenCode** | `.opencode/plugins/spec-superflow.js` 或 `.agents/skills -> skills/` | 已提供入口 |
 | **WorkBuddy** | `npx spec-superflow@latest install-workbuddy` | 已提供安装器 |
 | **Trae IDE / TRAE Work** | `.trae/skills/`、`~/.trae/skills/` 或上传 zip/.skill | 手动/导入 |
 
-> 完整安装说明见 [INSTALL.md](INSTALL.md)。
+> 共支持 17 个平台，完整安装说明见 [INSTALL.md](INSTALL.md)，支持矩阵见 [docs/platform-matrix.md](docs/platform-matrix.md)。
 
 ### CLI 工具链
 
@@ -121,10 +129,18 @@ npx spec-superflow list          # 或通过 npx 使用
 | `ssf audit <dir>` | 生成决策点审计报告 |
 | `ssf install-cursor` | 部署到 Cursor `.cursor/` 目录 |
 | `ssf install-workbuddy` | 部署到 WorkBuddy marketplace 并启用技能 |
+| `ssf install-cline` | 部署到 Cline `.cline/` + `.clinerules/` |
+| `ssf install-kiro` | 部署到 Kiro `.kiro/` + `.kiro/steering/` |
+| `ssf install-windsurf` | 部署到 Windsurf `.windsurf/` + `.windsurf/rules/` |
+| `ssf install-qwen` | 部署到 Qwen Code `.qwen/` + `.qwen/rules/` |
+| `ssf install-amazon-q` | 部署到 Amazon Q `.amazonq/` + `.amazonq/rules/` |
+| `ssf install-roocode` | 部署到 Roo Code `.roo/` + `.roo/rules/` |
+| `ssf install-continue` | 部署到 Continue `.continue/` + `.continue/rules/` |
+| `ssf install-pi` | 部署到 Pi `.pi/skills/`（无规则目录） |
 
 ### 版本
 
-- 当前版本：`v0.8.12`
+- 当前版本：`v0.8.13`
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -119,7 +119,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.8.12`
+- Current: `v0.8.13`
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)
 - Changelog: [CHANGELOG.md](../CHANGELOG.md)

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -1,0 +1,44 @@
+# 平台支持矩阵
+
+spec-superflow 共支持 **17 个** AI 编程平台。每个平台按三层接入：
+
+- **Skills** — 9 个 skill 部署到平台技能目录（`${CLAUDE_PLUGIN_ROOT}` 重写为绝对路径）。
+- **Rules** — phase-guard 规则文件部署到平台规则目录，被平台自动加载为常驻上下文（守卫机制）。
+- **Hooks** — SessionStart 上下文注入钩子（仅在该平台原生支持且已验证时接入）。
+
+## 矩阵
+
+| # | 平台 | Skills | Rules（路径 / 格式） | Hooks |
+|---|------|:------:|----------------------|:-----:|
+| 1 | Claude Code | ✅ | `.claude/rules/` · md | ✅ SessionStart |
+| 2 | Cursor | ✅ | `.cursor/rules/` · mdc | ✅ sessionStart |
+| 3 | OpenAI Codex CLI | ✅ | marketplace · md | ✅ |
+| 4 | OpenAI Codex App | ✅ | marketplace · md | ✅ |
+| 5 | GitHub Copilot CLI | ✅ | `.github/instructions/` · copilot | ✅ |
+| 6 | Gemini CLI | ✅ | `GEMINI.md`（无 rules 目录） | ✅ |
+| 7 | OpenCode | ✅ | `.opencode/` · md | — |
+| 8 | WorkBuddy | ✅ | — | — |
+| 9 | Trae | ✅ | — | — |
+| 10 | Cline | ✅ | `.clinerules/`（项目根）· md | — |
+| 11 | Kiro | ✅ | `.kiro/steering/` · md | — ¹ |
+| 12 | Windsurf | ✅ | `.windsurf/rules/` · md | — ¹ |
+| 13 | Qwen Code | ✅ | `.qwen/rules/` · md | — ¹ |
+| 14 | Amazon Q Developer | ✅ | `.amazonq/rules/` · md | — ¹ |
+| 15 | Roo Code | ✅ | `.roo/rules/` · md | — |
+| 16 | Continue | ✅ | `.continue/rules/` · md | — |
+| 17 | Pi | ✅ | —（无规则目录） | — |
+
+> ¹ Kiro / Windsurf / Qwen / Amazon Q 平台原生支持 hooks（comet 源码确认 hookFormat 分别为 kiro / windsurf / qwen / claude-code），但 spec-superflow 的 SessionStart 钩子在这些平台的可用性尚未逐一验证，故 v0.8.13 暂不写入 hook 配置，避免塞入失效配置。上下文注入由 phase-guard 规则（平台自动加载）承担。后续版本将逐平台验证后补齐。
+
+## 路径来源
+
+所有 `skillsDir` / `rulesDir` / `rulesFormat` / `hookFormat` 均与 [comet](https://github.com/rpamis/comet) 的 `src/core/platforms.ts` 交叉核实，并对照各平台官方约定。spec-superflow 的守卫机制是 **phase-guard 规则文件**（平台自动加载），而非 comet 的 PreToolUse 钩子——这是两层架构的根本区别。
+
+## 安装命令速查
+
+```bash
+npx spec-superflow@latest install-<id>
+# <id> ∈ {cline, kiro, windsurf, qwen, amazon-q, roocode, continue, pi, cursor, workbuddy}
+```
+
+Claude Code / Codex / Copilot / Gemini / OpenCode / Trae 走各自 marketplace 或本地目录，详见 [INSTALL.md](../INSTALL.md)。

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.8.12: conditional injection — detects artifacts, injects workflow-start pointer
+# v0.8.13: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Three platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.8.12.
+Current version: v0.8.13.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.8.12",
+  "version": "0.8.13",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/scripts/install-amazon-q.mjs
+++ b/scripts/install-amazon-q.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-amazon-q.mjs — deploy spec-superflow for Amazon Q Developer CLI
+// Skills → .amazonq/skills/, phase-guard rule → .amazonq/rules/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('amazon-q').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-cline.mjs
+++ b/scripts/install-cline.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-cline.mjs — deploy spec-superflow for Cline
+// Skills → .cline/skills/, phase-guard rule → .clinerules/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('cline').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-continue.mjs
+++ b/scripts/install-continue.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-continue.mjs — deploy spec-superflow for Continue
+// Skills → .continue/skills/, phase-guard rule → .continue/rules/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('continue').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-kiro.mjs
+++ b/scripts/install-kiro.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-kiro.mjs — deploy spec-superflow for Kiro
+// Skills → .kiro/skills/, phase-guard rule → .kiro/steering/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('kiro').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-pi.mjs
+++ b/scripts/install-pi.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-pi.mjs — deploy spec-superflow for Pi agent
+// Skills → .pi/skills/ (global: .pi/agent/skills/). No rules dir — invoke "/workflow-start" manually.
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('pi').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-qwen.mjs
+++ b/scripts/install-qwen.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-qwen.mjs — deploy spec-superflow for Qwen Code
+// Skills → .qwen/skills/, phase-guard rule → .qwen/rules/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('qwen').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-roocode.mjs
+++ b/scripts/install-roocode.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-roocode.mjs — deploy spec-superflow for Roo Code
+// Skills → .roo/skills/, phase-guard rule → .roo/rules/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('roocode').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/install-windsurf.mjs
+++ b/scripts/install-windsurf.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// scripts/install-windsurf.mjs — deploy spec-superflow for Windsurf
+// Skills → .windsurf/skills/, phase-guard rule → .windsurf/rules/phase-guard.md
+import { installPlatform } from './lib/install.mjs';
+
+installPlatform('windsurf').catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/cmd-install-amazon-q.mjs
+++ b/scripts/lib/cmd-install-amazon-q.mjs
@@ -1,0 +1,11 @@
+// ssf install-amazon-q — deploy spec-superflow for Amazon Q Developer. Delegates to scripts/install-amazon-q.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-amazon-q.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-cline.mjs
+++ b/scripts/lib/cmd-install-cline.mjs
@@ -1,0 +1,11 @@
+// ssf install-cline — deploy spec-superflow for Cline. Delegates to scripts/install-cline.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-cline.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-continue.mjs
+++ b/scripts/lib/cmd-install-continue.mjs
@@ -1,0 +1,11 @@
+// ssf install-continue — deploy spec-superflow for Continue. Delegates to scripts/install-continue.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-continue.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-kiro.mjs
+++ b/scripts/lib/cmd-install-kiro.mjs
@@ -1,0 +1,11 @@
+// ssf install-kiro — deploy spec-superflow for Kiro. Delegates to scripts/install-kiro.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-kiro.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-pi.mjs
+++ b/scripts/lib/cmd-install-pi.mjs
@@ -1,0 +1,11 @@
+// ssf install-pi — deploy spec-superflow for Pi agent. Delegates to scripts/install-pi.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-pi.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-qwen.mjs
+++ b/scripts/lib/cmd-install-qwen.mjs
@@ -1,0 +1,11 @@
+// ssf install-qwen — deploy spec-superflow for Qwen Code. Delegates to scripts/install-qwen.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-qwen.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-roocode.mjs
+++ b/scripts/lib/cmd-install-roocode.mjs
@@ -1,0 +1,11 @@
+// ssf install-roocode — deploy spec-superflow for Roo Code. Delegates to scripts/install-roocode.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-roocode.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/cmd-install-windsurf.mjs
+++ b/scripts/lib/cmd-install-windsurf.mjs
@@ -1,0 +1,11 @@
+// ssf install-windsurf — deploy spec-superflow for Windsurf. Delegates to scripts/install-windsurf.mjs
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const installScript = join(__dirname, '..', 'install-windsurf.mjs');
+
+export async function run(args) {
+  execFileSync(process.execPath, [installScript, ...args], { stdio: 'inherit' });
+}

--- a/scripts/lib/install.mjs
+++ b/scripts/lib/install.mjs
@@ -1,0 +1,259 @@
+// scripts/lib/install.mjs
+// Shared installer for spec-superflow cross-platform deployment.
+//
+// Mirrors the proven logic of scripts/install-cursor.mjs, parameterized by a
+// PlatformConfig from ./platforms.mjs. For each platform it:
+//   1. Resolves the plugin source (latest GitHub release or --local <path>).
+//   2. Copies RUNTIME_DIRS (scripts/docs/templates/dist/hooks) to
+//      <skillsDir>/spec-superflow/ so ${CLAUDE_PLUGIN_ROOT}/... resolves.
+//   3. Copies skills/ to <skillsDir>/skills/ with ${CLAUDE_PLUGIN_ROOT}
+//      rewritten to the absolute plugin root.
+//   4. Writes a phase-guard rule file to the platform's rules directory
+//      (when the platform has one) so the workflow entry rule is auto-included.
+//
+// spec-superflow's guard is the phase-guard RULE (auto-included by the
+// platform), not a PreToolUse hook; no hook configs are written here.
+
+import { existsSync, mkdirSync, readdirSync, statSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { cp, writeFile, mkdtemp } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { getPlatform, rulesTargetDir, phaseGuardFileName } from './platforms.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultPluginRoot = resolve(__dirname, '..', '..'); // repo root when run from clone
+
+const GITHUB_REPO = 'MageByte-Zero/spec-superflow';
+const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+
+// Directories needed at runtime by skills (referenced via ${CLAUDE_PLUGIN_ROOT}).
+const RUNTIME_DIRS = ['scripts', 'docs', 'templates', 'dist', 'hooks'];
+
+function ensureDir(dir) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+async function fetchLatestTag() {
+  const res = await fetch(GITHUB_API_URL);
+  if (!res.ok) {
+    throw new Error(`GitHub API failed: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  if (!data.tag_name) {
+    throw new Error('GitHub API response missing tag_name');
+  }
+  return data.tag_name;
+}
+
+async function cloneRelease(tag) {
+  const tmpDir = await mkdtemp(join('/tmp', 'spec-superflow-'));
+  const url = `https://github.com/${GITHUB_REPO}.git`;
+  console.log(`📥 Cloning ${tag} into ${tmpDir} ...`);
+  execFileSync('git', ['clone', '--depth', '1', '--branch', tag, url, tmpDir], {
+    stdio: 'inherit',
+  });
+  return tmpDir;
+}
+
+/** Recursively copy a directory; returns the number of top-level entries. */
+async function copyDir(src, dst) {
+  if (!existsSync(src)) return 0;
+  ensureDir(dst);
+  const entries = readdirSync(src);
+  for (const name of entries) {
+    const srcPath = join(src, name);
+    const dstPath = join(dst, name);
+    const st = statSync(srcPath);
+    if (st.isDirectory()) {
+      await copyDir(srcPath, dstPath);
+    } else {
+      await cp(srcPath, dstPath, { force: true });
+    }
+  }
+  return entries.length;
+}
+
+/**
+ * Copy skills to target, replacing ${CLAUDE_PLUGIN_ROOT} with the actual
+ * plugin root path so skill instructions resolve in the target platform.
+ */
+async function copySkillsWithRoot(sourceSkills, targetSkills, pluginRootAbs) {
+  // Clean old skill directories before copying.
+  if (existsSync(targetSkills)) {
+    const oldEntries = readdirSync(targetSkills).filter(name => {
+      const full = join(targetSkills, name);
+      try { return statSync(full).isDirectory(); } catch { return false; }
+    });
+    for (const name of oldEntries) {
+      rmSync(join(targetSkills, name), { recursive: true, force: true });
+    }
+  }
+  ensureDir(targetSkills);
+  const entries = readdirSync(sourceSkills).filter(name => {
+    const full = join(sourceSkills, name);
+    try { return statSync(full).isDirectory(); } catch { return false; }
+  });
+
+  function rewriteRoot(filePath) {
+    if (!existsSync(filePath)) return;
+    let content = readFileSync(filePath, 'utf-8');
+    if (content.includes('${CLAUDE_PLUGIN_ROOT}')) {
+      content = content.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRootAbs);
+      writeFileSync(filePath, content, 'utf-8');
+    }
+  }
+
+  for (const name of entries) {
+    const src = join(sourceSkills, name);
+    const dst = join(targetSkills, name);
+    await cp(src, dst, { recursive: true, force: true });
+    rewriteRoot(join(dst, 'SKILL.md'));
+    // Also fix sub-prompt / reference markdown files in the skill dir.
+    for (const sub of readdirSync(dst).filter(f => f.endsWith('.md') && f !== 'SKILL.md')) {
+      rewriteRoot(join(dst, sub));
+    }
+  }
+  return entries.length;
+}
+
+/** Phase-guard rule content. `mdc` gets Cursor frontmatter; `md`/`copilot` stay plain. */
+function phaseGuardContent(rulesFormat, platformId) {
+  const body = `# Phase Guard — spec-superflow (${platformId})
+
+## 入口规则
+
+- 所有工作必须从 "/workflow-start" 入口开始。
+- 在 .spec-superflow.yaml 中确认当前 state 和 workflow 模式之前，不要开始写代码。
+
+## 全局禁止
+
+- 没有 execution-contract.md 或未经用户明确批准，不得进入实现。
+- 执行过程中如果发现需求/范围变化，必须回退到 specifying 或 bridging，而不是直接改代码。
+- 不要直接调用执行类 skill（如 "/build-executor"），必须通过入口路由。
+
+## 决策点协议
+
+- DP-0：设计前确认
+- DP-1：需求确认
+- DP-2：工件审查
+- DP-3：是否批准 execution contract？
+- DP-4：选择执行模式（Inline / Batch Inline / SDD）
+- DP-5：调试升级
+- DP-6：验证失败
+- DP-7：是否收口归档？
+
+> 本文件由 spec-superflow 安装脚本生成（platform: ${platformId}）；
+> 对具体变更的 guard 内容请运行 \`ssf inject <change-dir>\` 更新。
+`;
+  if (rulesFormat === 'mdc') {
+    return `---
+description: spec-superflow phase guard — 防止阶段漂移和未授权实现
+alwaysApply: true
+---
+
+${body}`;
+  }
+  return body;
+}
+
+/**
+ * Install spec-superflow for a platform.
+ *
+ * @param {string} platformId - one of NEW_PLATFORM_IDS
+ * @param {Object} [opts]
+ * @param {string} [opts.local]  - deploy from a local repo path instead of release
+ * @param {string} [opts.tag]    - specific release tag to install
+ * @param {string} [opts.cwd]    - target project root (defaults to process.cwd())
+ */
+export async function installPlatform(platformId, opts = {}) {
+  const platform = getPlatform(platformId);
+  const { values } = parseArgs({
+    options: {
+      local: { type: 'string' },
+      tag: { type: 'string' },
+    },
+    // No `args` => parseArgs reads process.argv.slice(2), so `--local`/`--tag`
+    // passed on the CLI (or forwarded by cmd-install-<id>.mjs) are honored.
+  });
+  const local = opts.local ?? values.local;
+  const tag = opts.tag ?? values.tag;
+
+  const targetRoot = opts.cwd || process.cwd();
+
+  let pluginRoot = defaultPluginRoot;
+  let isTemp = false;
+  let installedTag = null;
+
+  if (local) {
+    pluginRoot = resolve(local);
+    console.log(`📁 Using local repo: ${pluginRoot}`);
+  } else {
+    installedTag = tag || await fetchLatestTag();
+    console.log(`⬆️  Installing spec-superflow ${installedTag} for ${platform.name} ...`);
+    pluginRoot = await cloneRelease(installedTag);
+    isTemp = true;
+  }
+
+  const sourceSkills = join(pluginRoot, 'skills');
+  if (!existsSync(sourceSkills)) {
+    console.error(`❌ skills/ directory not found at ${pluginRoot}`);
+    if (isTemp) rmSync(pluginRoot, { recursive: true, force: true });
+    process.exit(1);
+  }
+
+  // Target paths (project-local scope).
+  const targetPluginDir = join(targetRoot, platform.skillsDir, 'spec-superflow');
+  const targetSkills = join(targetRoot, platform.skillsDir, 'skills');
+  const pluginRootAbs = resolve(targetPluginDir);
+
+  try {
+    // 1. Copy runtime dependencies to <skillsDir>/spec-superflow/
+    console.log('📋 Copying runtime dependencies...');
+    for (const dir of RUNTIME_DIRS) {
+      const src = join(pluginRoot, dir);
+      const dst = join(targetPluginDir, dir);
+      if (existsSync(src)) {
+        const count = await copyDir(src, dst);
+        console.log(`   ${dir}/ → ${dst} (${count} entries)`);
+      } else {
+        console.log(`   ${dir}/ — skipped (not found)`);
+      }
+    }
+
+    // 2. Copy skills to <skillsDir>/skills/ with CLAUDE_PLUGIN_ROOT replaced
+    const count = await copySkillsWithRoot(sourceSkills, targetSkills, pluginRootAbs);
+    console.log(`   skills/ → ${targetSkills} (${count} skills, paths rewritten)`);
+
+    // 3. Write phase-guard rule (when the platform has a rules directory)
+    const rulesDir = rulesTargetDir(platform, targetRoot);
+    if (rulesDir) {
+      ensureDir(rulesDir);
+      const fileName = phaseGuardFileName(platform.rulesFormat);
+      const ruleFile = join(rulesDir, fileName);
+      await writeFile(ruleFile, phaseGuardContent(platform.rulesFormat, platformId), 'utf-8');
+      console.log(`   phase guard → ${ruleFile}`);
+    } else {
+      console.log(`   phase guard — skipped (${platform.name} has no rules directory)`);
+    }
+
+    console.log(`\n✅ ${platform.name} install complete:`);
+    console.log(`   Plugin root: ${pluginRootAbs}`);
+    if (installedTag) {
+      console.log(`   Version:     ${installedTag}`);
+    }
+    if (rulesDir) {
+      console.log(`\nNext: the phase-guard rule is auto-included. Try "/workflow-start".`);
+    } else {
+      console.log(`\nNext: ${platform.name} has no rules dir — invoke "/workflow-start" manually to start.`);
+    }
+    if (platform.notes) {
+      console.log(`   Note: ${platform.notes}`);
+    }
+  } finally {
+    if (isTemp) {
+      rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  }
+}

--- a/scripts/lib/platforms.mjs
+++ b/scripts/lib/platforms.mjs
@@ -1,0 +1,155 @@
+// scripts/lib/platforms.mjs
+// Platform registry for spec-superflow cross-platform installers.
+//
+// All paths verified against comet (https://github.com/rpamis/comet)
+// src/core/platforms.ts and each platform's documented conventions.
+// spec-superflow's guard mechanism is the phase-guard RULE file (auto-included
+// by the platform), not a PreToolUse hook; therefore `supportsHooks`/
+// `hookFormat` are recorded for documentation accuracy only — the shared
+// installer does not write hook configs for these platforms (SessionStart
+// wiring is deferred until each platform's session-start support is
+// individually verified).
+
+import { join } from 'node:path';
+
+/**
+ * @typedef {Object} PlatformConfig
+ * @property {string} id              - platform identifier (cli arg / install-<id>)
+ * @property {string} name            - human-readable name
+ * @property {string} skillsDir       - project-local skills base dir (e.g. '.cline')
+ * @property {string} [globalSkillsDir] - global (user-level) skills base dir
+ * @property {string} [rulesBaseDir]  - base dir for rules; '' = project root;
+ *                                      defaults to skillsDir when omitted
+ * @property {string} [rulesDir]      - rules subdirectory (omit => no rules)
+ * @property {'md'|'mdc'|'copilot'} [rulesFormat] - rule file format
+ * @property {boolean} [supportsHooks]   - platform supports hooks (info only)
+ * @property {string} [hookFormat]       - native hook config format (info only)
+ * @property {string} [notes]            - install / usage notes
+ */
+
+/** Platforms added by the v0.8.13 platform-expansion PR. */
+export const NEW_PLATFORMS = [
+  {
+    id: 'cline',
+    name: 'Cline',
+    skillsDir: '.cline',
+    globalSkillsDir: '.cline',
+    // Cline reads .clinerules/*.md at project root (not inside .cline/).
+    rulesBaseDir: '',
+    rulesDir: '.clinerules',
+    rulesFormat: 'md',
+    supportsHooks: false,
+    notes: 'Cline auto-includes .clinerules/*.md as always-on context.',
+  },
+  {
+    id: 'kiro',
+    name: 'Kiro',
+    skillsDir: '.kiro',
+    globalSkillsDir: '.kiro',
+    rulesDir: 'steering',
+    rulesFormat: 'md',
+    supportsHooks: true,
+    hookFormat: 'kiro',
+    notes: 'AWS Kiro IDE reads .kiro/steering/*.md as steering rules.',
+  },
+  {
+    id: 'windsurf',
+    name: 'Windsurf',
+    skillsDir: '.windsurf',
+    globalSkillsDir: '.windsurf',
+    rulesDir: 'rules',
+    rulesFormat: 'md',
+    supportsHooks: true,
+    hookFormat: 'windsurf',
+    notes: 'Codeium Windsurf reads .windsurf/rules/*.md as rules.',
+  },
+  {
+    id: 'qwen',
+    name: 'Qwen Code',
+    skillsDir: '.qwen',
+    globalSkillsDir: '.qwen',
+    rulesDir: 'rules',
+    rulesFormat: 'md',
+    supportsHooks: true,
+    hookFormat: 'qwen',
+    notes: 'Qwen Code CLI (Gemini CLI fork) reads .qwen/rules/*.md.',
+  },
+  {
+    id: 'amazon-q',
+    name: 'Amazon Q Developer',
+    skillsDir: '.amazonq',
+    globalSkillsDir: '.amazonq',
+    rulesDir: 'rules',
+    rulesFormat: 'md',
+    supportsHooks: true,
+    hookFormat: 'claude-code',
+    notes: 'Amazon Q Developer CLI reads .amazonq/rules/*.md as rules.',
+  },
+  {
+    id: 'roocode',
+    name: 'Roo Code',
+    skillsDir: '.roo',
+    globalSkillsDir: '.roo',
+    rulesDir: 'rules',
+    rulesFormat: 'md',
+    supportsHooks: false,
+    notes: 'Roo Code (Roo Cline) reads .roo/rules/*.md as rules.',
+  },
+  {
+    id: 'continue',
+    name: 'Continue',
+    skillsDir: '.continue',
+    globalSkillsDir: '.continue',
+    rulesDir: 'rules',
+    rulesFormat: 'md',
+    supportsHooks: false,
+    notes: 'Continue (VS Code) reads .continue/rules/*.md as rules.',
+  },
+  {
+    id: 'pi',
+    name: 'Pi',
+    skillsDir: '.pi',
+    globalSkillsDir: '.pi/agent',
+    // Pi has no rules directory — skills-only deployment.
+    rulesDir: undefined,
+    rulesFormat: undefined,
+    supportsHooks: false,
+    notes: 'Pi agent reads skills from .pi/ (global: .pi/agent/). No rules dir; invoke "/workflow-start" manually.',
+  },
+];
+
+/** Lookup a new platform config by id. */
+export function getPlatform(id) {
+  const p = NEW_PLATFORMS.find(x => x.id === id);
+  if (!p) {
+    throw new Error(
+      `Unknown platform: "${id}". Available: ${NEW_PLATFORMS.map(x => x.id).join(', ')}`,
+    );
+  }
+  return p;
+}
+
+/** All platform ids added by this PR. */
+export const NEW_PLATFORM_IDS = NEW_PLATFORMS.map(p => p.id);
+
+/**
+ * Compute the project-local rules target directory for a platform.
+ * Mirrors comet: rules go to (rulesBaseDir || skillsDir)/rulesDir.
+ * For Cline, rulesBaseDir='' places .clinerules/ at project root.
+ */
+export function rulesTargetDir(platform, targetRoot) {
+  if (!platform.rulesDir) return null;
+  const base = platform.rulesBaseDir !== undefined ? platform.rulesBaseDir : platform.skillsDir;
+  // join(targetRoot, '', '.clinerules') === targetRoot/.clinerules
+  return join(targetRoot, base, platform.rulesDir);
+}
+
+/** Phase-guard rule file name for a rules format. */
+export function phaseGuardFileName(rulesFormat) {
+  switch (rulesFormat) {
+    case 'mdc': return 'phase-guard.mdc';
+    case 'copilot': return 'spec-superflow.instructions.md';
+    case 'md':
+    default: return 'phase-guard.md';
+  }
+}

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -16,6 +16,14 @@ const COMMANDS = {
   audit:          () => import('./lib/cmd-audit.mjs'),
   'install-cursor': () => import('./lib/cmd-install-cursor.mjs'),
   'install-workbuddy': () => import('./lib/cmd-install-workbuddy.mjs'),
+  'install-cline':    () => import('./lib/cmd-install-cline.mjs'),
+  'install-kiro':     () => import('./lib/cmd-install-kiro.mjs'),
+  'install-windsurf': () => import('./lib/cmd-install-windsurf.mjs'),
+  'install-qwen':     () => import('./lib/cmd-install-qwen.mjs'),
+  'install-amazon-q': () => import('./lib/cmd-install-amazon-q.mjs'),
+  'install-roocode':  () => import('./lib/cmd-install-roocode.mjs'),
+  'install-continue': () => import('./lib/cmd-install-continue.mjs'),
+  'install-pi':       () => import('./lib/cmd-install-pi.mjs'),
 };
 
 const HELP = `spec-superflow (ssf) — Spec-first workflow CLI
@@ -34,6 +42,14 @@ Commands:
   audit <dir>           Generate decision-point-audit.md from .spec-superflow.yaml
   install-cursor        Deploy skills/scripts/docs to .cursor/ (local Cursor setup)
   install-workbuddy     Deploy skills to WorkBuddy marketplace and enable them
+  install-cline         Deploy to .cline/ + .clinerules/ (Cline)
+  install-kiro          Deploy to .kiro/ + .kiro/steering/ (Kiro)
+  install-windsurf      Deploy to .windsurf/ + .windsurf/rules/ (Windsurf)
+  install-qwen          Deploy to .qwen/ + .qwen/rules/ (Qwen Code)
+  install-amazon-q      Deploy to .amazonq/ + .amazonq/rules/ (Amazon Q Developer)
+  install-roocode       Deploy to .roo/ + .roo/rules/ (Roo Code)
+  install-continue      Deploy to .continue/ + .continue/rules/ (Continue)
+  install-pi            Deploy to .pi/skills/ (Pi agent; no rules dir)
 
 Options:
   --help, -h            Show this help message
@@ -53,6 +69,7 @@ Examples:
   ssf state get changes/my-change/ batches_completed
   ssf install-cursor
   ssf install-workbuddy
+  ssf install-cline --local /path/to/spec-superflow
 `;
 
 async function main() {


### PR DESCRIPTION
## Summary

将 spec-superflow 的安装支持从 9 个平台扩展到 **17 个**，新增 8 个 AI 编程平台的一键安装器，平台覆盖面对齐 [comet](https://github.com/rpamis/comet)。

## New platforms

| 平台 | 安装命令 | skills / rules 落点 |
|------|---------|---------------------|
| Cline | `ssf install-cline` | `.cline/skills/` + `.clinerules/phase-guard.md` |
| Kiro | `ssf install-kiro` | `.kiro/skills/` + `.kiro/steering/phase-guard.md` |
| Windsurf | `ssf install-windsurf` | `.windsurf/skills/` + `.windsurf/rules/phase-guard.md` |
| Qwen Code | `ssf install-qwen` | `.qwen/skills/` + `.qwen/rules/phase-guard.md` |
| Amazon Q Developer | `ssf install-amazon-q` | `.amazonq/skills/` + `.amazonq/rules/phase-guard.md` |
| Roo Code | `ssf install-roocode` | `.roo/skills/` + `.roo/rules/phase-guard.md` |
| Continue | `ssf install-continue` | `.continue/skills/` + `.continue/rules/phase-guard.md` |
| Pi | `ssf install-pi` | `.pi/skills/`（无规则目录） |

## Architecture

- **`scripts/lib/platforms.mjs`** — 平台注册表，所有 `skillsDir`/`rulesDir`/`rulesFormat`/`hookFormat` 与 comet `src/core/platforms.ts` 交叉核实。
- **`scripts/lib/install.mjs`** — 共享安装器（镜像 `install-cursor.mjs` 成熟逻辑，参数化）：拉 release / `--local` → 拷 RUNTIME_DIRS → 拷 skills 并重写 `${CLAUDE_PLUGIN_ROOT}` → 写 phase-guard 规则。
- 8 个 `install-<id>.mjs`（薄壳）+ 8 个 `lib/cmd-install-<id>.mjs`（CLI wrapper）。
- `ssf` 注册 8 个 `install-<id>` 子命令；`npx spec-superflow@latest install-<id>` 一键部署。

spec-superflow 的守卫机制是 **phase-guard 规则文件**（平台自动加载），而非 comet 的 PreToolUse 钩子。Kiro/Windsurf/Qwen/Amazon Q 原生支持 hooks，但 SessionStart 在这些平台的可用性未逐一验证，v0.8.13 暂不写入 hook 配置（避免塞失效配置），由 phase-guard 规则承担上下文注入。

## Verification

- ✅ 8/8 安装器本地 `--local` 冒烟测试通过（9 skills + RUNTIME_DIRS + phase-guard + `${CLAUDE_PLUGIN_ROOT}` 重写）
- ✅ `ssf install-kiro --local` CLI 路由验证通过
- ✅ `npm test`：233 tests pass
- ✅ `ssf doctor`：all checks passed（0.8.13 一致、9/9 skills）
- ✅ 版本一致性：10 manifest fields 全部 0.8.13
- ✅ 新增 CI job `platform-install-smoke`（8 平台 matrix，PR/push 触发）

## Docs

- INSTALL.md：平台总览表 9→17 行 + 8 个平台完整章节
- README.md：平台表 + CLI 命令表扩充
- docs/platform-matrix.md：17 × Skills/Rules/Hooks 支持矩阵（新增）

## Out of scope (follow-up)

- 剩余 14 个 comet 平台（Junie/Bob/ForgeCode/Crush/iFlow/CoStrict/Factory/KiloCode/Auggie/Lingma/KimiCode/Antigravity×2）→ v0.8.14+
- Kiro/Windsurf/Qwen/Amazon Q 的 SessionStart hook 验证后补齐

## Release plan

合并后打 tag `v0.8.13` 触发 release 工作流（npm publish + GitHub Release）。