### PR TITLE
feat: add task checkpoints and optional prototype handoffs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -680,6 +680,20 @@ ssf inject changes/my-change --platforms all
 
 省略 `--platforms` 时，只有在项目里**恰好检测到一个**平台标记时才会自动注入；如果检测到多个平台，必须显式传 `--platforms <platform>` 或 `--platforms all`。
 
+### 会话恢复与可选 prototype
+
+```bash
+ssf checkpoint save changes/my-change --task 1.1 --next "Run focused tests"
+ssf checkpoint list changes/my-change
+ssf checkpoint show changes/my-change 1.1
+ssf handoff create changes/my-change --type research --objective "Compare approaches" --expected-output "Recommendation" --acceptance "Evidence recorded"
+ssf handoff list changes/my-change
+ssf handoff finish changes/my-change <handoff-id>
+ssf handoff resolve changes/my-change <handoff-id> --decision accept
+```
+
+Checkpoint 是任务级恢复上下文。`result-ready` handoff 在继续受影响的工作前必须显式审阅并 resolve。Prototype 只在用户明确确认后创建；后端、CLI、配置和内部重构不会自动进入 prototype 流程。handoff 结果不会自动修改 `design.md` 或 `tasks.md`。
+
 ## 验证
 
 安装后验证：

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ npx spec-superflow list          # 或通过 npx 使用
 | `ssf state <sub> <dir>` | 管理 `.spec-superflow.yaml` 状态文件 |
 | `ssf inject <dir>` | 生成 phase-guard 产物；仅在检测到单一平台标记时可省略 `--platforms` |
 | `ssf audit <dir>` | 生成决策点审计报告 |
+| `ssf checkpoint save <dir> --task <id> --next <text>` | 保存任务级会话恢复点 |
+| `ssf checkpoint list <dir>` | 列出 checkpoint 及 stale 状态 |
+| `ssf checkpoint show <dir> <id>` | 查看单个恢复点 |
+| `ssf handoff create <dir> --type <type> ...` | 创建 prototype/research/experiment handoff |
+| `ssf handoff list <dir>` | 列出 handoff 生命周期状态 |
+| `ssf handoff finish <dir> <id>` | 校验 handoff 结果 |
+| `ssf handoff resolve <dir> <id> --decision <decision>` | 记录显式 handoff 决策 |
 | `ssf install-cursor` | 部署到 Cursor `.cursor/` 目录 |
 | `ssf install-workbuddy` | 部署到 WorkBuddy marketplace 插件（含 skills/rules/runtime） |
 | `ssf install-cline` | 部署到 Cline `.cline/` + `.clinerules/` |
@@ -153,6 +160,16 @@ ssf inject changes/my-change --platforms all
 ```
 
 省略 `--platforms` 时，只有在项目中**恰好检测到一个**平台标记时才会自动写入；如果检测到多个平台，必须显式指定 `--platforms <platform>` 或 `--platforms all`。
+
+会话恢复与可选 prototype：
+
+```bash
+ssf checkpoint save changes/my-change --task 1.1 --next "Run focused tests"
+ssf checkpoint list changes/my-change
+ssf handoff create changes/my-change --type research --objective "Compare approaches" --expected-output "Recommendation" --acceptance "Evidence recorded"
+```
+
+Prototype 只在用户明确确认后创建；后端、CLI、配置和内部重构不会自动进入 prototype 流程。handoff 结果不会自动修改 `design.md` 或 `tasks.md`。
 
 Delta spec 的规范路径是 `specs/<capability>/spec.md`；扁平的 `specs/<capability>.md` 和根级 `specs/spec.md` 不会被视为合法规范。
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -114,6 +114,13 @@ npm install -g spec-superflow
 | `ssf state <sub> <dir>` | Manage `.spec-superflow.yaml` state file |
 | `ssf inject <dir>` | Generate phase-guard artifacts; omit `--platforms` only when exactly one platform marker is detected |
 | `ssf audit <dir>` | Generate decision-point audit report |
+| `ssf checkpoint save <dir> --task <id> --next <text>` | Save a task-level recovery checkpoint |
+| `ssf checkpoint list <dir>` | List checkpoints and stale status |
+| `ssf checkpoint show <dir> <id>` | Show one recovery checkpoint |
+| `ssf handoff create <dir> --type <type> ...` | Create a prototype/research/experiment handoff |
+| `ssf handoff list <dir>` | List handoff lifecycle status |
+| `ssf handoff finish <dir> <id>` | Validate a handoff result |
+| `ssf handoff resolve <dir> <id> --decision <decision>` | Record an explicit handoff decision |
 | `ssf install-cursor` | Deploy to `.cursor/` directory |
 | `ssf install-workbuddy` | Deploy to WorkBuddy marketplace and enable skills |
 
@@ -132,6 +139,18 @@ ssf inject changes/my-change --platforms all
 ```
 
 If `--platforms` is omitted, injection only proceeds when exactly one project marker is detected. Ambiguous projects must use `--platforms <platform>` or `--platforms all`.
+
+Session recovery and optional prototypes:
+
+```bash
+ssf checkpoint save changes/my-change --task 1.1 --next "Run focused tests"
+ssf checkpoint list changes/my-change
+ssf handoff create changes/my-change --type research --objective "Compare approaches" --expected-output "Recommendation" --acceptance "Evidence recorded"
+```
+
+Prototype work starts only after explicit user confirmation. Backend, CLI,
+configuration, and internal-refactor work does not enter the prototype route
+automatically. Handoff results never edit `design.md` or `tasks.md` automatically.
 
 Canonical delta specs live at `specs/<capability>/spec.md`; flat `specs/<capability>.md` and root-level `specs/spec.md` are not valid canonical paths.
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -66,6 +66,22 @@
 - `closing` — successful completion with verification
 - `abandoned` — change abandoned (no delta spec merge, no further transitions allowed)
 
+## Recovery Overlays
+
+Checkpoints, handoffs, and prototypes are durable overlays, not workflow states.
+They do not add transitions to the state machine or change the meaning of the
+eight core states.
+
+- `ssf checkpoint save <change-dir> --task <id> --next <text>` records task-level
+  recovery context under `.superpowers/sdd/checkpoints/`.
+- `ssf handoff create <change-dir> --type <type> ...` creates explicit side-work
+  contracts under `.superpowers/sdd/handoffs/`.
+- `workflow-start` lists overlays before normal routing. `result-ready` handoffs
+  require explicit review and resolution before affected work resumes; stale
+  checkpoints remain historical evidence only.
+- Prototype work is optional and requires explicit user confirmation. Results
+  are reviewed manually and never mutate `design.md` or `tasks.md`.
+
 ## Transitions
 
 ```text

--- a/scripts/lib/cmd-checkpoint.mjs
+++ b/scripts/lib/cmd-checkpoint.mjs
@@ -38,8 +38,8 @@ export async function run(args) {
       evidence: values.verification,
       review: values.review,
       risk: values.risk,
-      'commit-start': values['commit-start'],
-      'commit-end': values['commit-end'],
+      commitStart: values['commit-start'],
+      commitEnd: values['commit-end'],
     });
     if (values.json) {
       console.log(JSON.stringify({ ok: true, checkpoint }));
@@ -108,5 +108,11 @@ function renderCheckpoint(checkpoint) {
     '',
     '## Risk',
     checkpoint.risk,
+    '',
+    '## Commit Start',
+    checkpoint.commit_start,
+    '',
+    '## Commit End',
+    checkpoint.commit_end,
   ].join('\n');
 }

--- a/scripts/lib/cmd-checkpoint.mjs
+++ b/scripts/lib/cmd-checkpoint.mjs
@@ -1,0 +1,112 @@
+// scripts/lib/cmd-checkpoint.mjs - ssf checkpoint recovery records
+import { parseArgs } from 'node:util';
+import { getCheckpoint, listCheckpoints, saveCheckpoint } from './sdd-overlay.mjs';
+
+const USAGE = 'Usage: ssf checkpoint <save|list|show> <change-dir> [options]';
+
+export async function run(args) {
+  const { positionals, values } = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      task: { type: 'string' }, next: { type: 'string' }, completed: { type: 'string' },
+      verification: { type: 'string' }, review: { type: 'string' }, risk: { type: 'string' },
+      'commit-start': { type: 'string' }, 'commit-end': { type: 'string' },
+      json: { type: 'boolean', default: false },
+    },
+  });
+
+  const subcommand = positionals[0];
+  const changeDir = positionals[1];
+  if (!subcommand || !changeDir) usage();
+
+  if (!['save', 'list', 'show'].includes(subcommand)) {
+    console.error(`Unknown checkpoint subcommand: ${subcommand}. Valid: save, list, show`);
+    process.exit(2);
+  }
+
+  if (subcommand === 'save') {
+    if (!hasText(values.task) || !hasText(values.next)) {
+      console.error('Usage: ssf checkpoint save <change-dir> --task <id> --next <text>');
+      process.exit(2);
+    }
+
+    const checkpoint = saveCheckpoint(changeDir, {
+      taskId: values.task,
+      next: values.next,
+      completed: values.completed,
+      evidence: values.verification,
+      review: values.review,
+      risk: values.risk,
+      'commit-start': values['commit-start'],
+      'commit-end': values['commit-end'],
+    });
+    if (values.json) {
+      console.log(JSON.stringify({ ok: true, checkpoint }));
+    } else {
+      console.log(`Checkpoint saved: ${checkpoint.task_id}`);
+    }
+    return;
+  }
+
+  if (subcommand === 'list') {
+    const checkpoints = listCheckpoints(changeDir);
+    if (values.json) {
+      console.log(JSON.stringify({ ok: true, checkpoints }));
+    } else if (checkpoints.length === 0) {
+      console.log('No checkpoints found.');
+    } else {
+      for (const checkpoint of checkpoints) {
+        console.log(`${checkpoint.task_id}  status=${checkpoint.stale ? 'stale' : 'current'}  stale=${checkpoint.stale}`);
+      }
+    }
+    return;
+  }
+
+  const taskId = positionals[2];
+  if (!taskId) usage('Usage: ssf checkpoint show <change-dir> <id>');
+  const checkpoint = getCheckpoint(changeDir, taskId);
+  if (!checkpoint) {
+    console.error(`Checkpoint '${taskId}' was not found`);
+    process.exit(1);
+  }
+
+  if (values.json) {
+    console.log(JSON.stringify({ ok: true, checkpoint }));
+  } else {
+    console.log(renderCheckpoint(checkpoint));
+  }
+}
+
+function hasText(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function usage(message = USAGE) {
+  console.error(message);
+  process.exit(2);
+}
+
+function renderCheckpoint(checkpoint) {
+  return [
+    `# Checkpoint: ${checkpoint.task_id}`,
+    '',
+    `Status: ${checkpoint.stale ? 'stale' : 'current'}`,
+    `Created: ${checkpoint.created_at}`,
+    '',
+    '## Next',
+    checkpoint.next,
+    '',
+    '## Completed',
+    checkpoint.completed,
+    '',
+    '## Evidence',
+    checkpoint.evidence,
+    '',
+    '## Review',
+    checkpoint.review,
+    '',
+    '## Risk',
+    checkpoint.risk,
+  ].join('\n');
+}

--- a/scripts/lib/cmd-handoff.mjs
+++ b/scripts/lib/cmd-handoff.mjs
@@ -1,0 +1,94 @@
+// ssf handoff contract lifecycle commands.
+import { parseArgs } from 'node:util';
+import {
+  HANDOFF_DECISIONS, HANDOFF_TYPES, createHandoff, finishHandoff, listHandoffs, resolveHandoff,
+} from './sdd-overlay.mjs';
+
+const USAGE = 'Usage: ssf handoff <create|list|finish|resolve> <change-dir> [options]';
+
+export async function run(args) {
+  const { positionals, values } = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      type: { type: 'string' }, objective: { type: 'string' },
+      'expected-output': { type: 'string' }, acceptance: { type: 'string' },
+      boundary: { type: 'string', multiple: true }, decision: { type: 'string' },
+      'acknowledge-source-drift': { type: 'boolean', default: false },
+      json: { type: 'boolean', default: false },
+    },
+  });
+
+  const subcommand = positionals[0];
+  const changeDir = positionals[1];
+  if (!subcommand || !changeDir) usage();
+
+  if (!['create', 'list', 'finish', 'resolve'].includes(subcommand)) {
+    console.error(`Unknown handoff subcommand: ${subcommand}. Valid: create, list, finish, resolve`);
+    process.exit(2);
+  }
+
+  if (subcommand === 'create') {
+    if (!hasText(values.type) || !hasText(values.objective)
+      || !hasText(values['expected-output']) || !hasText(values.acceptance)) {
+      usage('Usage: ssf handoff create <change-dir> --type <type> --objective <text> --expected-output <text> --acceptance <text>');
+    }
+    if (!HANDOFF_TYPES.has(values.type)) {
+      throw new Error(`Unsupported handoff type '${values.type}'`);
+    }
+
+    const handoff = createHandoff(changeDir, {
+      type: values.type,
+      title: values.objective,
+      question: `Expected output: ${values['expected-output']}`,
+      context: `Acceptance: ${values.acceptance}`,
+      source: renderBoundaries(values.boundary),
+    });
+    output(values.json, { ok: true, handoff }, `Handoff created: ${handoff.id}`);
+    return;
+  }
+
+  if (subcommand === 'list') {
+    const handoffs = listHandoffs(changeDir);
+    output(values.json, { ok: true, handoffs }, handoffs.length === 0
+      ? 'No handoffs found.'
+      : handoffs.map(handoff => `${handoff.id}  type=${handoff.type}  status=${handoff.status}`).join('\n'));
+    return;
+  }
+
+  const id = positionals[2];
+  if (!hasText(id)) usage(`Usage: ssf handoff ${subcommand} <change-dir> <id>${subcommand === 'resolve' ? ' --decision <accept|reject|defer>' : ''}`);
+
+  if (subcommand === 'finish') {
+    const handoff = finishHandoff(changeDir, id);
+    output(values.json, { ok: true, handoff }, `Handoff finished: ${handoff.id}`);
+    return;
+  }
+
+  if (!hasText(values.decision)) {
+    usage('Usage: ssf handoff resolve <change-dir> <id> --decision <accept|reject|defer>');
+  }
+  if (!HANDOFF_DECISIONS.has(values.decision)) {
+    throw new Error(`Unsupported handoff decision '${values.decision}'`);
+  }
+
+  const handoff = resolveHandoff(changeDir, id, values.decision, values['acknowledge-source-drift']);
+  output(values.json, { ok: true, handoff }, `Handoff resolved: ${handoff.id} (${handoff.decision})`);
+}
+
+function hasText(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function renderBoundaries(boundaries) {
+  return boundaries?.length ? `Boundaries:\n${boundaries.map(boundary => `- ${boundary}`).join('\n')}` : 'Not recorded';
+}
+
+function output(json, payload, text) {
+  console.log(json ? JSON.stringify(payload) : text);
+}
+
+function usage(message = USAGE) {
+  console.error(message);
+  process.exit(2);
+}

--- a/scripts/lib/sdd-overlay.mjs
+++ b/scripts/lib/sdd-overlay.mjs
@@ -1,0 +1,244 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { computeArtifactsHash } from './hash.mjs';
+import { readState } from './state-loader.mjs';
+
+export const HANDOFF_TYPES = new Set(['prototype', 'research', 'experiment']);
+export const HANDOFF_DECISIONS = new Set(['accept', 'reject', 'defer']);
+export const RESULT_HEADINGS = [
+  'Conclusion', 'Evidence', 'Produced Artifacts', 'Risks', 'Suggested Changes',
+];
+
+export function getOverlayPaths(changeDir) {
+  const root = join(changeDir, '.superpowers', 'sdd');
+  return {
+    root,
+    checkpoints: join(root, 'checkpoints'),
+    handoffs: join(root, 'handoffs'),
+  };
+}
+
+export function computeTaskHash(changeDir, taskId) {
+  const tasks = readFileSync(join(changeDir, 'tasks.md'), 'utf8');
+  const escaped = taskId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = tasks.match(new RegExp(`^- \\[([ xX])\\] ${escaped}\\s+.+$`, 'm'));
+  if (!match) throw new Error(`Task '${taskId}' was not found in tasks.md`);
+  return `sha256:${createHash('sha256').update(match[0]).digest('hex')}`;
+}
+
+export function saveCheckpoint(changeDir, input) {
+  requireText(input?.taskId, 'taskId');
+  requireText(input?.next, 'next');
+  const paths = getOverlayPaths(changeDir);
+  mkdirSync(paths.checkpoints, { recursive: true });
+  const record = {
+    task_id: input.taskId,
+    task_hash: computeTaskHash(changeDir, input.taskId),
+    next: input.next,
+    completed: input.completed ?? 'Not recorded',
+    evidence: input.evidence ?? 'Not recorded',
+    review: input.review ?? 'Not recorded',
+    risk: input.risk ?? 'Not recorded',
+    created_at: new Date().toISOString(),
+  };
+  const targetPath = join(paths.checkpoints, `${safeName(input.taskId)}.md`);
+  atomicWrite(targetPath, renderRecord(record, `# Checkpoint: ${input.taskId}`, checkpointBody(record)));
+  return readCheckpoint(targetPath);
+}
+
+export function listCheckpoints(changeDir) {
+  const directory = getOverlayPaths(changeDir).checkpoints;
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory).filter(name => name.endsWith('.md')).sort()
+    .map(name => readCheckpoint(join(directory, name)));
+}
+
+export function getCheckpoint(changeDir, taskId) {
+  const filePath = join(getOverlayPaths(changeDir).checkpoints, `${safeName(taskId)}.md`);
+  if (!existsSync(filePath)) return null;
+  return readCheckpoint(filePath);
+}
+
+export function createHandoff(changeDir, input) {
+  requireText(input?.type, 'type');
+  if (!HANDOFF_TYPES.has(input.type)) throw new Error(`Unsupported handoff type '${input.type}'`);
+  requireText(input?.title, 'title');
+  requireText(input?.question, 'question');
+  const paths = getOverlayPaths(changeDir);
+  const id = input.id || `${Date.now()}-${randomUUID().slice(0, 8)}`;
+  const directory = join(paths.handoffs, safeName(id));
+  mkdirSync(directory, { recursive: true });
+  const state = readState(changeDir);
+  const metadata = {
+    id,
+    type: input.type,
+    title: input.title,
+    question: input.question,
+    context: input.context ?? 'Not recorded',
+    source: input.source ?? 'Not recorded',
+    core_state: state.state,
+    state: state.state,
+    source_artifacts_hash: computeArtifactsHash(changeDir),
+    status: 'active',
+    created_at: new Date().toISOString(),
+  };
+  atomicWrite(join(directory, 'HANDOFF.md'), renderRecord(
+    metadata,
+    `# Handoff: ${input.title}`,
+    handoffBody(metadata),
+  ));
+  atomicWrite(join(directory, 'RESULT.md'), renderResultTemplate());
+  return readHandoff(directory);
+}
+
+export function listHandoffs(changeDir) {
+  const directory = getOverlayPaths(changeDir).handoffs;
+  if (!existsSync(directory)) return [];
+  return readdirSync(directory, { withFileTypes: true }).filter(entry => entry.isDirectory())
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(entry => readHandoff(join(directory, entry.name)));
+}
+
+export function finishHandoff(changeDir, id) {
+  const handoff = getHandoff(changeDir, id);
+  if (!handoff) throw new Error(`Handoff '${id}' was not found`);
+  const resultPath = join(handoff.directory, 'RESULT.md');
+  const result = parseResult(readFileSync(resultPath, 'utf8'));
+  for (const heading of RESULT_HEADINGS) {
+    if (!result[heading]) throw new Error(`${heading} must contain non-empty content`);
+  }
+  if (handoff.status !== 'active') throw new Error(`Handoff '${id}' is not active`);
+  const metadata = { ...handoff.metadata, status: 'result-ready', result_ready_at: new Date().toISOString() };
+  atomicWrite(join(handoff.directory, 'HANDOFF.md'), renderRecord(
+    metadata,
+    `# Handoff: ${metadata.title}`,
+    handoffBody(metadata),
+  ));
+  return readHandoff(handoff.directory);
+}
+
+export function resolveHandoff(changeDir, id, decision, acknowledgeSourceDrift) {
+  if (!HANDOFF_DECISIONS.has(decision)) throw new Error(`Unsupported handoff decision '${decision}'`);
+  const handoff = getHandoff(changeDir, id);
+  if (!handoff) throw new Error(`Handoff '${id}' was not found`);
+  if (handoff.status !== 'result-ready') throw new Error(`Handoff '${id}' is not result-ready`);
+  const sourceDrift = handoff.source_artifacts_hash !== computeArtifactsHash(changeDir);
+  if (sourceDrift && acknowledgeSourceDrift !== true) {
+    throw new Error('resolve requires acknowledge-source-drift');
+  }
+  const metadata = {
+    ...handoff.metadata,
+    status: 'resolved',
+    decision,
+    resolved_at: new Date().toISOString(),
+    source_drift: sourceDrift,
+    source_drift_acknowledged: sourceDrift && acknowledgeSourceDrift === true,
+  };
+  atomicWrite(join(handoff.directory, 'HANDOFF.md'), renderRecord(
+    metadata,
+    `# Handoff: ${metadata.title}`,
+    handoffBody(metadata),
+  ));
+  return readHandoff(handoff.directory);
+}
+
+function checkpointBody(record) {
+  return [
+    `## Next\n${record.next}`,
+    `## Completed\n${record.completed}`,
+    `## Evidence\n${record.evidence}`,
+    `## Review\n${record.review}`,
+    `## Risk\n${record.risk}`,
+  ].join('\n\n');
+}
+
+function handoffBody(metadata) {
+  return [
+    `## Question\n${metadata.question}`,
+    `## Context\n${metadata.context}`,
+    `## Source\n${metadata.source}`,
+  ].join('\n\n');
+}
+
+function renderResultTemplate() {
+  return `${RESULT_HEADINGS.map(heading => `## ${heading}\n`).join('\n')}\n`;
+}
+
+function readCheckpoint(filePath) {
+  const { metadata } = parseRecord(readFileSync(filePath, 'utf8'));
+  const currentHash = computeTaskHash(dirname(dirname(dirname(dirname(filePath)))), metadata.task_id);
+  return { ...metadata, stale: metadata.task_hash !== currentHash };
+}
+
+function readHandoff(directory) {
+  const { metadata } = parseRecord(readFileSync(join(directory, 'HANDOFF.md'), 'utf8'));
+  return { ...metadata, directory };
+}
+
+function getHandoff(changeDir, id) {
+  const directory = join(getOverlayPaths(changeDir).handoffs, safeName(id));
+  if (!existsSync(join(directory, 'HANDOFF.md'))) return null;
+  const { metadata } = parseRecord(readFileSync(join(directory, 'HANDOFF.md'), 'utf8'));
+  return { ...metadata, directory, metadata };
+}
+
+function renderRecord(metadata, title, body) {
+  const frontmatter = Object.entries(metadata)
+    .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+    .join('\n');
+  return `---\n${frontmatter}\n---\n\n${title}\n\n${body}\n`;
+}
+
+function parseRecord(content) {
+  const lines = content.split('\n');
+  if (lines[0] !== '---') throw new Error('Record is missing frontmatter');
+  const end = lines.indexOf('---', 1);
+  if (end < 0) throw new Error('Record frontmatter is not closed');
+  const metadata = {};
+  for (const line of lines.slice(1, end)) {
+    const match = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (!match) continue;
+    metadata[match[1]] = parseScalar(match[2]);
+  }
+  return { metadata, body: lines.slice(end + 1).join('\n') };
+}
+
+function parseScalar(value) {
+  if (value.startsWith('"')) {
+    try { return JSON.parse(value); } catch { return value; }
+  }
+  return value;
+}
+
+function parseResult(content) {
+  const result = {};
+  let currentHeading = null;
+  for (const line of content.split('\n')) {
+    const heading = line.match(/^## (.+?)\s*$/)?.[1];
+    if (heading && RESULT_HEADINGS.includes(heading)) {
+      currentHeading = heading;
+      result[currentHeading] = '';
+    } else if (currentHeading) {
+      result[currentHeading] += `${line}\n`;
+    }
+  }
+  for (const heading of RESULT_HEADINGS) result[heading] = result[heading]?.trim() || '';
+  return result;
+}
+
+function atomicWrite(targetPath, content) {
+  const tempPath = `${targetPath}.tmp-${process.pid}-${randomUUID()}`;
+  writeFileSync(tempPath, content, 'utf8');
+  renameSync(tempPath, targetPath);
+}
+
+function requireText(value, field) {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${field} is required`);
+}
+
+function safeName(value) {
+  return String(value).replace(/[^A-Za-z0-9._-]/g, '_');
+}

--- a/scripts/lib/sdd-overlay.mjs
+++ b/scripts/lib/sdd-overlay.mjs
@@ -169,7 +169,15 @@ function renderResultTemplate() {
 
 function readCheckpoint(filePath) {
   const { metadata } = parseRecord(readFileSync(filePath, 'utf8'));
-  const currentHash = computeTaskHash(dirname(dirname(dirname(dirname(filePath)))), metadata.task_id);
+  let currentHash;
+  try {
+    currentHash = computeTaskHash(dirname(dirname(dirname(dirname(filePath)))), metadata.task_id);
+  } catch (error) {
+    if (error instanceof Error && error.message === `Task '${metadata.task_id}' was not found in tasks.md`) {
+      return { ...metadata, stale: true };
+    }
+    throw error;
+  }
   return { ...metadata, stale: metadata.task_hash !== currentHash };
 }
 

--- a/scripts/lib/sdd-overlay.mjs
+++ b/scripts/lib/sdd-overlay.mjs
@@ -11,6 +11,7 @@ export const HANDOFF_DECISIONS = new Set(['accept', 'reject', 'defer']);
 export const RESULT_HEADINGS = [
   'Conclusion', 'Evidence', 'Produced Artifacts', 'Risks', 'Suggested Changes',
 ];
+const HANDOFF_RESULT_FILE = 'HANDOFF_RESULT.md';
 
 export function getOverlayPaths(changeDir) {
   const root = join(changeDir, '.superpowers', 'sdd');
@@ -92,7 +93,7 @@ export function createHandoff(changeDir, input) {
     `# Handoff: ${input.title}`,
     handoffBody(metadata),
   ));
-  atomicWrite(join(directory, 'RESULT.md'), renderResultTemplate());
+  atomicWrite(join(directory, HANDOFF_RESULT_FILE), renderResultTemplate());
   return readHandoff(directory);
 }
 
@@ -107,7 +108,7 @@ export function listHandoffs(changeDir) {
 export function finishHandoff(changeDir, id) {
   const handoff = getHandoff(changeDir, id);
   if (!handoff) throw new Error(`Handoff '${id}' was not found`);
-  const resultPath = join(handoff.directory, 'RESULT.md');
+  const resultPath = join(handoff.directory, HANDOFF_RESULT_FILE);
   const result = parseResult(readFileSync(resultPath, 'utf8'));
   for (const heading of RESULT_HEADINGS) {
     if (!result[heading]) throw new Error(`${heading} must contain non-empty content`);

--- a/scripts/lib/sdd-overlay.mjs
+++ b/scripts/lib/sdd-overlay.mjs
@@ -42,6 +42,8 @@ export function saveCheckpoint(changeDir, input) {
     evidence: input.evidence ?? 'Not recorded',
     review: input.review ?? 'Not recorded',
     risk: input.risk ?? 'Not recorded',
+    commit_start: input.commitStart ?? 'Not recorded',
+    commit_end: input.commitEnd ?? 'Not recorded',
     created_at: new Date().toISOString(),
   };
   const targetPath = join(paths.checkpoints, `${safeName(input.taskId)}.md`);
@@ -152,6 +154,8 @@ function checkpointBody(record) {
     `## Evidence\n${record.evidence}`,
     `## Review\n${record.review}`,
     `## Risk\n${record.risk}`,
+    `## Commit Start\n${record.commit_start}`,
+    `## Commit End\n${record.commit_end}`,
   ].join('\n\n');
 }
 
@@ -169,6 +173,8 @@ function renderResultTemplate() {
 
 function readCheckpoint(filePath) {
   const { metadata } = parseRecord(readFileSync(filePath, 'utf8'));
+  metadata.commit_start ??= 'Not recorded';
+  metadata.commit_end ??= 'Not recorded';
   let currentHash;
   try {
     currentHash = computeTaskHash(dirname(dirname(dirname(dirname(filePath)))), metadata.task_id);

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -44,6 +44,20 @@ Commands:
   state <sub> <dir>     Manage .spec-superflow.yaml state (init|check|transition|get|rebuild)
   inject <dir>          Generate phase-guard artifacts; use --platforms <name|all> when platform is ambiguous
   audit <dir>           Generate decision-point-audit.md from .spec-superflow.yaml
+  checkpoint save <change-dir> --task <id> --next <text>
+                        Save a task-level recovery checkpoint
+  checkpoint list <change-dir>
+                        List checkpoints and stale status
+  checkpoint show <change-dir> <id>
+                        Show one recovery checkpoint
+  handoff create <change-dir> --type <type> --objective <text> --expected-output <text> --acceptance <text>
+                        Create an explicit prototype/research/experiment handoff
+  handoff list <change-dir>
+                        List active and completed handoffs
+  handoff finish <change-dir> <id>
+                        Validate a handoff result
+  handoff resolve <change-dir> <id> --decision <accept|reject|defer>
+                        Record the explicit handoff decision
   install-cursor        Deploy skills/scripts/docs to .cursor/ (local Cursor setup)
   install-workbuddy     Deploy skills to WorkBuddy marketplace and enable them
   install-cline         Deploy to .cline/ + .clinerules/ (Cline)
@@ -71,6 +85,9 @@ Examples:
   ssf state check changes/my-change/
   ssf state transition changes/my-change/ approved-for-build
   ssf state get changes/my-change/ batches_completed
+  ssf checkpoint save changes/my-change/ --task 1.1 --next "Run focused tests"
+  ssf checkpoint list changes/my-change/
+  ssf handoff create changes/my-change/ --type research --objective "Compare approaches" --expected-output "Recommendation" --acceptance "Evidence recorded"
   ssf install-cursor
   ssf install-workbuddy
   ssf install-cline --local /path/to/spec-superflow

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -15,6 +15,7 @@ const COMMANDS = {
   inject:         () => import('./lib/cmd-inject.mjs'),
   audit:          () => import('./lib/cmd-audit.mjs'),
   checkpoint:     () => import('./lib/cmd-checkpoint.mjs'),
+  handoff:        () => import('./lib/cmd-handoff.mjs'),
   isolate:        () => import('./lib/cmd-isolate.mjs'),
   'install-cursor': () => import('./lib/cmd-install-cursor.mjs'),
   'install-workbuddy': () => import('./lib/cmd-install-workbuddy.mjs'),

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -14,6 +14,7 @@ const COMMANDS = {
   state:          () => import('./lib/cmd-state.mjs'),
   inject:         () => import('./lib/cmd-inject.mjs'),
   audit:          () => import('./lib/cmd-audit.mjs'),
+  checkpoint:     () => import('./lib/cmd-checkpoint.mjs'),
   isolate:        () => import('./lib/cmd-isolate.mjs'),
   'install-cursor': () => import('./lib/cmd-install-cursor.mjs'),
   'install-workbuddy': () => import('./lib/cmd-install-workbuddy.mjs'),

--- a/skills/build-executor/SKILL.md
+++ b/skills/build-executor/SKILL.md
@@ -86,7 +86,21 @@ Track in `.superpowers/sdd/progress.md`. Check for existing ledger — completed
 
 For ≤3 tasks, no cross-module deps. Executes in current session.
 
-Per-task: extract brief → write failing test → confirm failure → implement → confirm green → checkpoint review (done-when criteria, SHALL/MUST verification) → commit → append to progress ledger.
+Per-task: extract brief → write failing test → confirm failure → implement → confirm green → checkpoint review (done-when criteria, SHALL/MUST verification) → commit → save a task-level recovery checkpoint when another task remains → append to progress ledger.
+
+After a task is committed and reviewed, when another task remains, save the
+recovery context with real evidence:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/spec-superflow.mjs" checkpoint save <change-dir> \
+  --task <completed-task-id> --next "<next task>" --completed "<completed work>" \
+  --verification "<verification report path>" --review "<review report path>" \
+  --risk "<open risk or None>" --commit-start <base-sha> --commit-end <head-sha>
+```
+
+This augments `.superpowers/sdd/progress.md`; it does not replace the progress
+ledger or add a new core workflow state. Do not claim a checkpoint is current
+when `ssf checkpoint list` reports it as stale.
 
 If task hits BLOCKED (3+ fix failures or changes outside declared scope), escalate to SDD.
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -21,6 +21,7 @@ Do NOT invoke for: general coding tasks outside spec-superflow changes, casual q
 
 1. **Update check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-update.mjs"`. Exit 0 → continue. Exit 1 → non-blocking upgrade reminder. Exit 2 → skip.
 2. **Inspect change folder**: Check for `proposal.md`, `specs/`, `design.md`, `tasks.md`, `execution-contract.md`. Answer: Is the change fuzzy? Artifacts missing/unstable? Contract exist? User approved contract? Execution in progress or blocked? In verification/wrap-up?
+3. **Overlay recovery scan**: Run `ssf handoff list <change-dir> --json` and `ssf checkpoint list <change-dir> --json`. A `result-ready` handoff requires explicit review and `ssf handoff resolve` before resuming the affected work. An `active` handoff is non-blocking side work. Show a non-stale checkpoint as recovery context; show a stale checkpoint only as historical evidence.
 
 ## DP-0: User Confirmation Gate
 
@@ -72,6 +73,24 @@ Delta specs exist that need merging, change closing with ADDED/MODIFIED/REMOVED/
 
 ### Route to abandoned
 User explicitly requests, bug-investigator escalates after 3+ failures AND user chooses, scope change makes change no longer worthwhile AND user confirms. Block from `closing` or `abandoned`.
+
+### Optional Prototype Handoff
+
+When the user's brief explicitly contains UI, screen, interaction, layout, UX,
+or product-experience uncertainty, ask once whether a prototype would reduce
+uncertainty. Do not create a prototype handoff or enter a prototype worktree
+until the user confirms. After confirmation:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/spec-superflow.mjs" handoff create <change-dir> \
+  --type prototype --objective "<confirmed objective>" \
+  --expected-output "<expected evidence>" --acceptance "<completion criterion>"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/spec-superflow.mjs" isolate <change-dir> prototype-<handoff-id>
+```
+
+Never suggest or enter this route automatically for backend, CLI, configuration,
+or internal-refactor work. Never pass `--force` to `ssf isolate` for prototype
+work.
 
 ### Fast-Path Routing
 - **Hotfix**: Route to contract-builder (minimal), skip need-explorer + spec-writer, guard check `exploring bridging --workflow hotfix`, then `bridging -> approved-for-build`, after DP-3 → build-executor (inline), after → release-archivist (lightweight). Hotfix may skip `proposal.md`, `design.md`, `tasks.md`, and `specs/`, but it still requires a fresh minimal `execution-contract.md` and DP-3 approval before build

--- a/tests/lib/cmd-checkpoint.test.mjs
+++ b/tests/lib/cmd-checkpoint.test.mjs
@@ -35,6 +35,13 @@ afterEach(() => {
 });
 
 describe('ssf checkpoint', () => {
+  it('advertises checkpoint and handoff syntax in --help', () => {
+    const result = runSsf(['--help']);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.match(result.stdout, /checkpoint save <change-dir>/);
+    assert.match(result.stdout, /handoff create <change-dir>/);
+  });
+
   it('saves and shows a task checkpoint', () => {
     const result = runSsf([
       'checkpoint', 'save', changeDir, '--task', '1.1', '--next', 'Run focused tests',

--- a/tests/lib/cmd-checkpoint.test.mjs
+++ b/tests/lib/cmd-checkpoint.test.mjs
@@ -42,7 +42,26 @@ describe('ssf checkpoint', () => {
       '--review', 'review.md', '--risk', 'None', '--commit-start', 'aaaaaaa', '--commit-end', 'bbbbbbb',
     ]);
     assert.equal(result.exitCode, 0, result.stderr);
-    assert.match(runSsf(['checkpoint', 'show', changeDir, '1.1']).stdout, /Run focused tests/);
+    const show = runSsf(['checkpoint', 'show', changeDir, '1.1', '--json']);
+    assert.equal(show.exitCode, 0, show.stderr);
+    const shown = JSON.parse(show.stdout).checkpoint;
+    assert.equal(shown.next, 'Run focused tests');
+    assert.equal(shown.completed, 'Added parser tests');
+    assert.equal(shown.evidence, 'tests/lib/sdd-overlay.test.mjs');
+    assert.equal(shown.review, 'review.md');
+    assert.equal(shown.risk, 'None');
+    assert.equal(shown.commit_start, 'aaaaaaa');
+    assert.equal(shown.commit_end, 'bbbbbbb');
+
+    const listed = runSsf(['checkpoint', 'list', changeDir, '--json']);
+    assert.equal(listed.exitCode, 0, listed.stderr);
+    const listedCheckpoint = JSON.parse(listed.stdout).checkpoints[0];
+    assert.equal(listedCheckpoint.completed, 'Added parser tests');
+    assert.equal(listedCheckpoint.evidence, 'tests/lib/sdd-overlay.test.mjs');
+    assert.equal(listedCheckpoint.review, 'review.md');
+    assert.equal(listedCheckpoint.risk, 'None');
+    assert.equal(listedCheckpoint.commit_start, 'aaaaaaa');
+    assert.equal(listedCheckpoint.commit_end, 'bbbbbbb');
   });
 
   it('rejects save without --next before creating a checkpoint file', () => {

--- a/tests/lib/cmd-checkpoint.test.mjs
+++ b/tests/lib/cmd-checkpoint.test.mjs
@@ -1,0 +1,72 @@
+// tests/lib/cmd-checkpoint.test.mjs
+// Dispatcher-level tests for ssf checkpoint.
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI = join(process.cwd(), 'scripts/spec-superflow.mjs');
+let changeDir;
+
+function runSsf(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI, ...args], {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      exitCode: error.status || 1,
+      stdout: error.stdout?.toString() || '',
+      stderr: error.stderr?.toString() || error.message,
+    };
+  }
+}
+
+beforeEach(() => {
+  changeDir = mkdtempSync(join(tmpdir(), 'ssf-checkpoint-'));
+  writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n\n- [ ] 1.1 Original task text\n');
+});
+
+afterEach(() => {
+  rmSync(changeDir, { recursive: true, force: true });
+});
+
+describe('ssf checkpoint', () => {
+  it('saves and shows a task checkpoint', () => {
+    const result = runSsf([
+      'checkpoint', 'save', changeDir, '--task', '1.1', '--next', 'Run focused tests',
+      '--completed', 'Added parser tests', '--verification', 'tests/lib/sdd-overlay.test.mjs',
+      '--review', 'review.md', '--risk', 'None', '--commit-start', 'aaaaaaa', '--commit-end', 'bbbbbbb',
+    ]);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.match(runSsf(['checkpoint', 'show', changeDir, '1.1']).stdout, /Run focused tests/);
+  });
+
+  it('rejects save without --next before creating a checkpoint file', () => {
+    const result = runSsf(['checkpoint', 'save', changeDir, '--task', '1.1']);
+    assert.equal(result.exitCode, 2);
+    assert.equal(existsSync(join(changeDir, '.superpowers', 'sdd', 'checkpoints', '1.1.md')), false);
+  });
+
+  it('lists a stale checkpoint as JSON', () => {
+    const save = runSsf(['checkpoint', 'save', changeDir, '--task', '1.1', '--next', 'Run focused tests']);
+    assert.equal(save.exitCode, 0, save.stderr);
+    writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n\n- [ ] 1.1 Changed task text\n');
+
+    const result = runSsf(['checkpoint', 'list', changeDir, '--json']);
+    assert.equal(result.exitCode, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.checkpoints.length, 1);
+    assert.equal(payload.checkpoints[0].task_id, '1.1');
+    assert.equal(payload.checkpoints[0].stale, true);
+  });
+
+  it('rejects an unknown task ID when showing a checkpoint', () => {
+    const result = runSsf(['checkpoint', 'show', changeDir, '9.9']);
+    assert.equal(result.exitCode, 1);
+  });
+});

--- a/tests/lib/cmd-handoff.test.mjs
+++ b/tests/lib/cmd-handoff.test.mjs
@@ -1,0 +1,137 @@
+// Dispatcher-level tests for ssf handoff.
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CLI = join(process.cwd(), 'scripts/spec-superflow.mjs');
+let changeDir;
+
+function runSsf(args) {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI, ...args], {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (error) {
+    return {
+      exitCode: error.status || 1,
+      stdout: error.stdout?.toString() || '',
+      stderr: error.stderr?.toString() || error.message,
+    };
+  }
+}
+
+beforeEach(() => {
+  changeDir = mkdtempSync(join(tmpdir(), 'ssf-handoff-'));
+  writeFileSync(join(changeDir, 'proposal.md'), '# Proposal\n\nA valid proposal.\n');
+  writeFileSync(join(changeDir, 'design.md'), '# Design\n\nA valid design.\n');
+  writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n\n- [ ] 1.1 Original task text\n');
+  writeFileSync(join(changeDir, '.spec-superflow.yaml'), 'state: executing\nworkflow: auto\n');
+});
+
+afterEach(() => {
+  rmSync(changeDir, { recursive: true, force: true });
+});
+
+describe('ssf handoff', () => {
+  it('creates, finishes, and resolves a prototype contract without mutating planning files', () => {
+    const designBefore = readFileSync(join(changeDir, 'design.md'));
+    const tasksBefore = readFileSync(join(changeDir, 'tasks.md'));
+    const create = runSsf([
+      'handoff', 'create', changeDir, '--type', 'prototype',
+      '--objective', 'Compare two filter interactions',
+      '--expected-output', 'A short recommendation with evidence',
+      '--acceptance', 'Document one recommended interaction',
+      '--boundary', 'Do not alter planning artifacts', '--boundary', 'Use only fixture data',
+    ]);
+    assert.equal(create.exitCode, 0, create.stderr);
+
+    const listed = runSsf(['handoff', 'list', changeDir, '--json']);
+    assert.equal(listed.exitCode, 0, listed.stderr);
+    const handoff = JSON.parse(listed.stdout).handoffs[0];
+    assert.equal(handoff.type, 'prototype');
+    assert.match(handoff.source, /- Do not alter planning artifacts/);
+    assert.match(handoff.source, /- Use only fixture data/);
+
+    writeFileSync(join(handoff.directory, 'RESULT.md'), validResult());
+    assert.equal(runSsf(['handoff', 'finish', changeDir, handoff.id]).exitCode, 0);
+    assert.equal(runSsf(['handoff', 'resolve', changeDir, handoff.id, '--decision', 'accept']).exitCode, 0);
+    assert.deepEqual(readFileSync(join(changeDir, 'design.md')), designBefore);
+    assert.deepEqual(readFileSync(join(changeDir, 'tasks.md')), tasksBefore);
+  });
+
+  it('rejects an unknown handoff type', () => {
+    const result = runSsf([
+      'handoff', 'create', changeDir, '--type', 'unknown', '--objective', 'Objective',
+      '--expected-output', 'Expected output', '--acceptance', 'Acceptance',
+    ]);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /Unsupported handoff type 'unknown'/);
+  });
+
+  it('rejects a result without evidence and leaves the handoff active', () => {
+    const handoff = createHandoff();
+    writeFileSync(join(handoff.directory, 'RESULT.md'), validResult().replace('Prototype screenshots and task notes.', ''));
+
+    const result = runSsf(['handoff', 'finish', changeDir, handoff.id]);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /Evidence must contain non-empty content/);
+    assert.equal(getHandoff(handoff.id).status, 'active');
+  });
+
+  it('rejects an active handoff resolution', () => {
+    const handoff = createHandoff();
+    const result = runSsf(['handoff', 'resolve', changeDir, handoff.id, '--decision', 'accept']);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /is not result-ready/);
+  });
+
+  it('rejects an unknown resolution decision', () => {
+    const handoff = createHandoff();
+    const result = runSsf(['handoff', 'resolve', changeDir, handoff.id, '--decision', 'ignore']);
+    assert.equal(result.exitCode, 1);
+    assert.match(result.stderr, /Unsupported handoff decision 'ignore'/);
+  });
+
+  it('requires acknowledgement when source artifacts drift', () => {
+    const handoff = createHandoff();
+    writeFileSync(join(handoff.directory, 'RESULT.md'), validResult());
+    assert.equal(runSsf(['handoff', 'finish', changeDir, handoff.id]).exitCode, 0);
+    writeFileSync(join(changeDir, 'proposal.md'), '# Proposal\n\nChanged after handoff creation.\n');
+
+    const unresolved = runSsf(['handoff', 'resolve', changeDir, handoff.id, '--decision', 'accept']);
+    assert.equal(unresolved.exitCode, 1);
+    assert.match(unresolved.stderr, /acknowledge-source-drift/);
+    assert.equal(runSsf([
+      'handoff', 'resolve', changeDir, handoff.id, '--decision', 'accept', '--acknowledge-source-drift',
+    ]).exitCode, 0);
+  });
+});
+
+function createHandoff() {
+  const result = runSsf([
+    'handoff', 'create', changeDir, '--type', 'research', '--objective', 'Inspect behavior',
+    '--expected-output', 'Document findings', '--acceptance', 'List evidence',
+  ]);
+  assert.equal(result.exitCode, 0, result.stderr);
+  return JSON.parse(runSsf(['handoff', 'list', changeDir, '--json']).stdout).handoffs[0];
+}
+
+function getHandoff(id) {
+  return JSON.parse(runSsf(['handoff', 'list', changeDir, '--json']).stdout)
+    .handoffs.find(handoff => handoff.id === id);
+}
+
+function validResult() {
+  return [
+    '## Conclusion\n\nKeep the compact filter interaction.',
+    '## Evidence\n\nPrototype screenshots and task notes.',
+    '## Produced Artifacts\n\nprototype/filter.md',
+    '## Risks\n\nKeyboard flow needs a follow-up.',
+    '## Suggested Changes\n\n- Add keyboard behavior to tasks.md.',
+    '',
+  ].join('\n');
+}

--- a/tests/lib/cmd-handoff.test.mjs
+++ b/tests/lib/cmd-handoff.test.mjs
@@ -56,7 +56,7 @@ describe('ssf handoff', () => {
     assert.match(handoff.source, /- Do not alter planning artifacts/);
     assert.match(handoff.source, /- Use only fixture data/);
 
-    writeFileSync(join(handoff.directory, 'RESULT.md'), validResult());
+    writeFileSync(join(handoff.directory, 'HANDOFF_RESULT.md'), validResult());
     assert.equal(runSsf(['handoff', 'finish', changeDir, handoff.id]).exitCode, 0);
     assert.equal(runSsf(['handoff', 'resolve', changeDir, handoff.id, '--decision', 'accept']).exitCode, 0);
     assert.deepEqual(readFileSync(join(changeDir, 'design.md')), designBefore);
@@ -74,7 +74,7 @@ describe('ssf handoff', () => {
 
   it('rejects a result without evidence and leaves the handoff active', () => {
     const handoff = createHandoff();
-    writeFileSync(join(handoff.directory, 'RESULT.md'), validResult().replace('Prototype screenshots and task notes.', ''));
+    writeFileSync(join(handoff.directory, 'HANDOFF_RESULT.md'), validResult().replace('Prototype screenshots and task notes.', ''));
 
     const result = runSsf(['handoff', 'finish', changeDir, handoff.id]);
     assert.equal(result.exitCode, 1);
@@ -98,7 +98,7 @@ describe('ssf handoff', () => {
 
   it('requires acknowledgement when source artifacts drift', () => {
     const handoff = createHandoff();
-    writeFileSync(join(handoff.directory, 'RESULT.md'), validResult());
+    writeFileSync(join(handoff.directory, 'HANDOFF_RESULT.md'), validResult());
     assert.equal(runSsf(['handoff', 'finish', changeDir, handoff.id]).exitCode, 0);
     writeFileSync(join(changeDir, 'proposal.md'), '# Proposal\n\nChanged after handoff creation.\n');
 

--- a/tests/lib/sdd-overlay.test.mjs
+++ b/tests/lib/sdd-overlay.test.mjs
@@ -1,0 +1,73 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  saveCheckpoint, listCheckpoints, createHandoff, listHandoffs, finishHandoff, resolveHandoff,
+} from '../../scripts/lib/sdd-overlay.mjs';
+
+let changeDir;
+
+const validHandoffInput = {
+  type: 'research',
+  title: 'Research findings',
+  question: 'Which approach should the implementation use?',
+  context: 'Compare the available implementation approaches.',
+  source: 'Local repository inspection',
+};
+
+beforeEach(() => {
+  changeDir = mkdtempSync(join(tmpdir(), 'sdd-overlay-'));
+  writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n\n- [ ] 1.1 Original task text\n');
+  writeFileSync(join(changeDir, 'proposal.md'), '# Proposal\n\nA valid proposal.\n');
+  writeFileSync(join(changeDir, 'design.md'), '# Design\n\nA valid design.\n');
+  writeFileSync(join(changeDir, '.spec-superflow.yaml'), 'state: executing\nworkflow: auto\n');
+});
+
+afterEach(() => {
+  rmSync(changeDir, { recursive: true, force: true });
+});
+
+describe('checkpoint storage', () => {
+  it('marks a checkpoint stale when its numbered task line changes', () => {
+    saveCheckpoint(changeDir, { taskId: '1.1', next: 'Run the focused test' });
+    writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n\n- [ ] 1.1 Changed task text\n');
+
+    assert.equal(listCheckpoints(changeDir)[0].stale, true);
+  });
+});
+
+describe('handoff storage', () => {
+  it('keeps a handoff active when finish validation fails', () => {
+    const handoff = createHandoff(changeDir, validHandoffInput);
+
+    assert.throws(() => finishHandoff(changeDir, handoff.id), /Conclusion/);
+    assert.equal(listHandoffs(changeDir)[0].status, 'active');
+  });
+
+  it('requires explicit drift acknowledgement before resolving', () => {
+    const handoff = createReadyHandoff();
+    writeFileSync(join(changeDir, 'design.md'), '# Changed design\n');
+
+    assert.throws(
+      () => resolveHandoff(changeDir, handoff.id, 'accept', false),
+      /acknowledge-source-drift/,
+    );
+    assert.equal(resolveHandoff(changeDir, handoff.id, 'accept', true).status, 'resolved');
+  });
+});
+
+function createReadyHandoff() {
+  const handoff = createHandoff(changeDir, validHandoffInput);
+  const resultPath = join(changeDir, '.superpowers', 'sdd', 'handoffs', handoff.id, 'RESULT.md');
+  writeFileSync(resultPath, [
+    '## Conclusion\nThe research is complete.',
+    '## Evidence\nRepository evidence was reviewed.',
+    '## Produced Artifacts\nThe handoff record was produced.',
+    '## Risks\nNo additional risks were found.',
+    '## Suggested Changes\nProceed with the selected approach.',
+    '',
+  ].join('\n'));
+  return finishHandoff(changeDir, handoff.id);
+}

--- a/tests/lib/sdd-overlay.test.mjs
+++ b/tests/lib/sdd-overlay.test.mjs
@@ -36,6 +36,13 @@ describe('checkpoint storage', () => {
 
     assert.equal(listCheckpoints(changeDir)[0].stale, true);
   });
+
+  it('marks a checkpoint stale when its task is removed', () => {
+    saveCheckpoint(changeDir, { taskId: '1.1', next: 'Run the focused test' });
+    writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n');
+
+    assert.equal(listCheckpoints(changeDir)[0].stale, true);
+  });
 });
 
 describe('handoff storage', () => {

--- a/tests/lib/sdd-overlay.test.mjs
+++ b/tests/lib/sdd-overlay.test.mjs
@@ -30,6 +30,29 @@ afterEach(() => {
 });
 
 describe('checkpoint storage', () => {
+  it('persists commit boundaries and recovery fields across list and show reads', () => {
+    saveCheckpoint(changeDir, {
+      taskId: '1.1',
+      next: 'Run the focused test',
+      completed: 'Added parser tests',
+      evidence: 'tests/lib/sdd-overlay.test.mjs',
+      review: 'review.md',
+      risk: 'None',
+      commitStart: 'aaaaaaa',
+      commitEnd: 'bbbbbbb',
+    });
+
+    const checkpoint = listCheckpoints(changeDir)[0];
+    assert.equal(checkpoint.task_id, '1.1');
+    assert.equal(checkpoint.next, 'Run the focused test');
+    assert.equal(checkpoint.completed, 'Added parser tests');
+    assert.equal(checkpoint.evidence, 'tests/lib/sdd-overlay.test.mjs');
+    assert.equal(checkpoint.review, 'review.md');
+    assert.equal(checkpoint.risk, 'None');
+    assert.equal(checkpoint.commit_start, 'aaaaaaa');
+    assert.equal(checkpoint.commit_end, 'bbbbbbb');
+  });
+
   it('marks a checkpoint stale when its numbered task line changes', () => {
     saveCheckpoint(changeDir, { taskId: '1.1', next: 'Run the focused test' });
     writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n\n- [ ] 1.1 Changed task text\n');

--- a/tests/lib/sdd-overlay.test.mjs
+++ b/tests/lib/sdd-overlay.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -69,6 +69,17 @@ describe('checkpoint storage', () => {
 });
 
 describe('handoff storage', () => {
+  it('creates HANDOFF.md and HANDOFF_RESULT.md and validates the latter on finish', () => {
+    const handoff = createHandoff(changeDir, validHandoffInput);
+    const handoffPath = join(handoff.directory, 'HANDOFF.md');
+    const resultPath = join(handoff.directory, 'HANDOFF_RESULT.md');
+
+    assert.equal(existsSync(handoffPath), true);
+    assert.equal(existsSync(resultPath), true);
+    writeFileSync(resultPath, validResult());
+    assert.equal(finishHandoff(changeDir, handoff.id).status, 'result-ready');
+  });
+
   it('keeps a handoff active when finish validation fails', () => {
     const handoff = createHandoff(changeDir, validHandoffInput);
 
@@ -90,14 +101,18 @@ describe('handoff storage', () => {
 
 function createReadyHandoff() {
   const handoff = createHandoff(changeDir, validHandoffInput);
-  const resultPath = join(changeDir, '.superpowers', 'sdd', 'handoffs', handoff.id, 'RESULT.md');
-  writeFileSync(resultPath, [
+  const resultPath = join(changeDir, '.superpowers', 'sdd', 'handoffs', handoff.id, 'HANDOFF_RESULT.md');
+  writeFileSync(resultPath, validResult());
+  return finishHandoff(changeDir, handoff.id);
+}
+
+function validResult() {
+  return [
     '## Conclusion\nThe research is complete.',
     '## Evidence\nRepository evidence was reviewed.',
     '## Produced Artifacts\nThe handoff record was produced.',
     '## Risks\nNo additional risks were found.',
     '## Suggested Changes\nProceed with the selected approach.',
     '',
-  ].join('\n'));
-  return finishHandoff(changeDir, handoff.id);
+  ].join('\n');
 }


### PR DESCRIPTION
## Summary

- Add task-level checkpoint storage with stale-task detection and recovery fields.
- Add explicit research, experiment, and optional prototype handoff lifecycles.
- Add CLI commands, workflow guidance, state-machine documentation, and installation examples.
- Keep prototype work opt-in and prevent automatic mutation of design.md or tasks.md.

Closes #8
Closes #31

## Validation

- `npm test` (291 passed)
- `npm run build`
- `node scripts/validate-artifacts docs/examples/add-dark-mode`
- `node scripts/validate-artifacts docs/examples/refactor-auth-boundary`
- `git diff --check main...HEAD`

The Superpowers design and plan files are local-only and are not included in this branch.