### PR TITLE
feat: add configurable model profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `spec-superflow` will be documented in this file.
 
 The format loosely follows Keep a Changelog.
 
+## [Unreleased]
+
+### Added
+
+- **#37 — Model profiles**：可在 `spec-superflow.config.json` 中为 `mechanical`、`standard`、`strong`、`review` 配置平台模型 ID，并用 `ssf config --resolve-model <profile>` 只读解析；不执行跨平台自动模型切换，也不新增 runtime dependency。
+
 ## [0.8.17] - 2026-07-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -256,6 +256,38 @@ Delta spec 的规范路径是 `specs/<capability>/spec.md`；扁平的 `specs/<c
 
 ---
 
+## 模型 Profile（可选配置）
+
+可以在项目根目录的 `spec-superflow.config.json` 中，为不同执行角色配置平台模型 ID：
+
+```json
+{
+  "models": {
+    "mechanical": "vendor-small",
+    "standard": "vendor-standard",
+    "strong": "vendor-strong",
+    "review": "vendor-review"
+  }
+}
+```
+
+| Profile | 角色 |
+|---|---|
+| `mechanical` | 低成本、机械性修改 |
+| `standard` | 集成与判断任务 |
+| `strong` | 架构、设计与最终审查 |
+| `review` | 与 diff 匹配的代码审查 |
+
+使用以下命令只读解析一个 profile：
+
+```bash
+ssf config --resolve-model mechanical
+```
+
+该命令只解析本地配置，不调用平台 API，也不切换当前会话模型。支持 `model` 字段的平台由控制器显式传入返回的模型 ID；若结果为 `configured: false`，则没有自动选择能力，不能臆造供应商模型，仍须遵守现有的显式指定 `model` 要求。
+
+---
+
 ## FAQ
 
 <details>

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -237,6 +237,38 @@ You: "add authorization to the API"
 
 ---
 
+## Model Profiles (Optional Configuration)
+
+Configure platform model IDs for execution roles in the project-root `spec-superflow.config.json`:
+
+```json
+{
+  "models": {
+    "mechanical": "vendor-small",
+    "standard": "vendor-standard",
+    "strong": "vendor-strong",
+    "review": "vendor-review"
+  }
+}
+```
+
+| Profile | Role |
+|---|---|
+| `mechanical` | Low-cost, routine edits |
+| `standard` | Integration and judgment work |
+| `strong` | Architecture, design, and final review |
+| `review` | Code review that matches the diff |
+
+Resolve a profile in read-only mode:
+
+```bash
+ssf config --resolve-model mechanical
+```
+
+This command only resolves local configuration, does not call platform APIs, and does not switch models in the current session. The controller explicitly passes the returned model ID only to platforms whose dispatch supports a `model` field. A `configured: false` result means automatic selection is unavailable: never invent a provider model and continue to meet the existing explicit `model` requirement.
+
+---
+
 ## FAQ
 
 <details>

--- a/scripts/lib/cmd-config.mjs
+++ b/scripts/lib/cmd-config.mjs
@@ -1,7 +1,7 @@
 // ssf config — display or modify configuration
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { loadConfig, getDefaults } from './config-loader.mjs';
+import { loadConfig, getDefaults, resolveModelProfile } from './config-loader.mjs';
 
 export async function run(args) {
   const config = loadConfig(process.cwd());
@@ -10,6 +10,20 @@ export async function run(args) {
   if (args.length === 0) {
     console.log('Effective configuration:');
     console.log(JSON.stringify(config, null, 2));
+    return;
+  }
+
+  if (args[0] === '--resolve-model') {
+    if (!args[1]) {
+      console.error('Usage: ssf config --resolve-model <profile>');
+      process.exit(2);
+    }
+    try {
+      console.log(JSON.stringify(resolveModelProfile(config, args[1])));
+    } catch (error) {
+      console.error(error.message);
+      process.exit(1);
+    }
     return;
   }
 
@@ -34,7 +48,7 @@ export async function run(args) {
   if (args[0] === '--set' && args[1]) {
     const eqIdx = args[1].indexOf('=');
     if (eqIdx === -1) {
-      console.error('Usage: ssf config --set <path>=<value>');
+      console.error('Usage: ssf config [--get <path>] [--set <path>=<value>] [--resolve-model <profile>]');
       process.exit(2);
     }
     const path = args[1].slice(0, eqIdx);
@@ -69,6 +83,6 @@ export async function run(args) {
     return;
   }
 
-  console.error('Usage: ssf config [--get <path>] [--set <path>=<value>]');
+  console.error('Usage: ssf config [--get <path>] [--set <path>=<value>] [--resolve-model <profile>]');
   process.exit(2);
 }

--- a/scripts/lib/config-loader.mjs
+++ b/scripts/lib/config-loader.mjs
@@ -21,6 +21,30 @@ const DEFAULTS = {
   },
 };
 
+export const MODEL_PROFILES = Object.freeze([
+  'mechanical', 'standard', 'strong', 'review',
+]);
+
+export function resolveModelProfile(config, profile) {
+  if (!MODEL_PROFILES.includes(profile)) {
+    throw new Error(
+      `Unknown model profile '${profile}'. Supported profiles: ${MODEL_PROFILES.join(', ')}`,
+    );
+  }
+
+  const models = config?.models;
+  if (!models || !Object.hasOwn(models, profile)) {
+    return { profile, model: null, configured: false };
+  }
+
+  const model = models[profile];
+  if (typeof model !== 'string' || model.trim().length === 0) {
+    throw new Error(`Invalid model profile: models.${profile} must be a non-empty string`);
+  }
+
+  return { profile, model, configured: true };
+}
+
 function deepMerge(target, source) {
   const result = { ...target };
   for (const key of Object.keys(source)) {

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -41,6 +41,7 @@ Commands:
   version <semver>      Sync version to all manifest files
   sync <change-dir>     Merge delta specs into main specs
   config [options]      Display or modify configuration
+  config --resolve-model <profile>  Resolve a configured model profile without switching models
   state <sub> <dir>     Manage .spec-superflow.yaml state (init|check|transition|get|rebuild)
   inject <dir>          Generate phase-guard artifacts; use --platforms <name|all> when platform is ambiguous
   audit <dir>           Generate decision-point-audit.md from .spec-superflow.yaml
@@ -80,6 +81,7 @@ Examples:
   ssf version 0.4.0
   ssf sync changes/v0.3.0-workflow-enhancements/
   ssf config --get execution.inlineThreshold
+  ssf config --resolve-model mechanical
   ssf config --set verification.language=zh
   ssf state init changes/my-change/
   ssf state check changes/my-change/

--- a/skills/build-executor/SKILL.md
+++ b/skills/build-executor/SKILL.md
@@ -77,7 +77,20 @@ For changes with multiple execution batches. Dispatch implementer subagent per t
 5. **Mark complete**: Append to `.superpowers/sdd/progress.md`: `Task N: complete (commits <base7>..<head7>, review clean)`
 
 ### Model Selection
-Use least powerful model per role: mechanical (cheap), integration/judgment (standard), architecture/design (most capable), review (match diff), final review (most capable). Always specify model explicitly.
+Use the configured profile that matches the task role. Resolve it before dispatch:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/spec-superflow.mjs" config --resolve-model <profile>
+```
+
+| Profile | Role |
+|---|---|
+| `mechanical` | Cheap, routine edits |
+| `standard` | Integration and judgment work |
+| `strong` | Architecture, design, and final review |
+| `review` | Review that matches the diff |
+
+For platforms whose dispatch supports a `model` field, explicitly pass the resolved `model` value. If the result is `configured: false`, automatic selection is unavailable: do not invent a provider model and do not bypass the existing requirement to specify `model` explicitly. Resolution only reads configuration; it does not switch models.
 
 ### Progress Ledger
 Track in `.superpowers/sdd/progress.md`. Check for existing ledger — completed tasks are done. After each batch: `node "${CLAUDE_PLUGIN_ROOT}/scripts/spec-superflow.mjs" state set <change-dir> batches_completed <N>`.

--- a/tests/lib/cmd-config.test.mjs
+++ b/tests/lib/cmd-config.test.mjs
@@ -45,27 +45,57 @@ describe('ssf config --resolve-model', () => {
     assert.match(result.stdout, /without switching models/);
   });
 
-  it('prints configured model profile JSON', () => {
-    writeConfig({ models: { mechanical: 'vendor-small' } });
-    const result = runSsf(['config', '--resolve-model', 'mechanical']);
+  it('prints configured standard model profile JSON through the dispatcher', () => {
+    writeConfig({ models: { standard: 'vendor-standard', strong: 'vendor-strong' } });
+    const result = runSsf(['config', '--resolve-model', 'standard']);
     assert.equal(result.exitCode, 0, result.stderr);
     assert.deepStrictEqual(JSON.parse(result.stdout), {
-      profile: 'mechanical', model: 'vendor-small', configured: true,
+      profile: 'standard', model: 'vendor-standard', configured: true,
     });
   });
 
-  it('prints a valid unmapped result and rejects invalid requests', () => {
+  it('prints configured strong model profile JSON through the dispatcher', () => {
+    writeConfig({ models: { standard: 'vendor-standard', strong: 'vendor-strong' } });
+    const result = runSsf(['config', '--resolve-model', 'strong']);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout), {
+      profile: 'strong', model: 'vendor-strong', configured: true,
+    });
+  });
+
+  it('prints a valid unmapped result', () => {
     writeConfig({ models: {} });
     const unmapped = runSsf(['config', '--resolve-model', 'review']);
     assert.equal(unmapped.exitCode, 0, unmapped.stderr);
     assert.deepStrictEqual(JSON.parse(unmapped.stdout), {
       profile: 'review', model: null, configured: false,
     });
-    assert.equal(runSsf(['config', '--resolve-model']).exitCode, 2);
-    assert.equal(runSsf(['config', '--resolve-model', 'fast']).exitCode, 1);
+  });
 
+  it('rejects an unknown profile with supported names in stderr', () => {
+    const unknown = runSsf(['config', '--resolve-model', 'fast']);
+    assert.equal(unknown.exitCode, 1);
+    assert.match(unknown.stderr,
+      /Unknown model profile 'fast'.*mechanical.*standard.*strong.*review/);
+  });
+
+  it('rejects a blank mapped profile with an actionable config path in stderr', () => {
     writeConfig({ models: { review: '' } });
-    assert.equal(runSsf(['config', '--resolve-model', 'review']).exitCode, 1);
+    const blank = runSsf(['config', '--resolve-model', 'review']);
+    assert.equal(blank.exitCode, 1);
+    assert.match(blank.stderr, /models\.review must be a non-empty string/);
+  });
+
+  it('rejects a non-string mapped profile with an actionable config path in stderr', () => {
+    writeConfig({ models: { strong: 42 } });
+    const nonString = runSsf(['config', '--resolve-model', 'strong']);
+    assert.equal(nonString.exitCode, 1);
+    assert.match(nonString.stderr, /models\.strong must be a non-empty string/);
+  });
+
+  it('rejects a missing profile argument and preserves normal config lookup', () => {
+    assert.equal(runSsf(['config', '--resolve-model']).exitCode, 2);
+    writeConfig({ models: {} });
     assert.equal(runSsf(['config', '--get', 'execution.inlineThreshold']).stdout.trim(), '3');
   });
 });

--- a/tests/lib/cmd-config.test.mjs
+++ b/tests/lib/cmd-config.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const CLI = join(process.cwd(), 'scripts/spec-superflow.mjs');
+let tempDir;
+
+before(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'ssf-cmd-config-test-'));
+});
+
+after(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeConfig(config) {
+  writeFileSync(join(tempDir, 'spec-superflow.config.json'), JSON.stringify(config));
+}
+
+function runSsf(args) {
+  try {
+    return {
+      exitCode: 0,
+      stdout: execFileSync(process.execPath, [CLI, ...args], {
+        cwd: tempDir, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+      }), stderr: '',
+    };
+  } catch (error) {
+    return {
+      exitCode: error.status ?? 1,
+      stdout: error.stdout?.toString() ?? '',
+      stderr: error.stderr?.toString() ?? error.message,
+    };
+  }
+}
+
+describe('ssf config --resolve-model', () => {
+  it('prints configured model profile JSON', () => {
+    writeConfig({ models: { mechanical: 'vendor-small' } });
+    const result = runSsf(['config', '--resolve-model', 'mechanical']);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout), {
+      profile: 'mechanical', model: 'vendor-small', configured: true,
+    });
+  });
+
+  it('prints a valid unmapped result and rejects invalid requests', () => {
+    writeConfig({ models: {} });
+    assert.deepStrictEqual(JSON.parse(runSsf(['config', '--resolve-model', 'review']).stdout), {
+      profile: 'review', model: null, configured: false,
+    });
+    assert.equal(runSsf(['config', '--resolve-model']).exitCode, 2);
+    assert.equal(runSsf(['config', '--resolve-model', 'fast']).exitCode, 1);
+
+    writeConfig({ models: { review: '' } });
+    assert.equal(runSsf(['config', '--resolve-model', 'review']).exitCode, 1);
+    assert.equal(runSsf(['config', '--get', 'execution.inlineThreshold']).stdout.trim(), '3');
+  });
+});

--- a/tests/lib/cmd-config.test.mjs
+++ b/tests/lib/cmd-config.test.mjs
@@ -49,7 +49,9 @@ describe('ssf config --resolve-model', () => {
 
   it('prints a valid unmapped result and rejects invalid requests', () => {
     writeConfig({ models: {} });
-    assert.deepStrictEqual(JSON.parse(runSsf(['config', '--resolve-model', 'review']).stdout), {
+    const unmapped = runSsf(['config', '--resolve-model', 'review']);
+    assert.equal(unmapped.exitCode, 0, unmapped.stderr);
+    assert.deepStrictEqual(JSON.parse(unmapped.stdout), {
       profile: 'review', model: null, configured: false,
     });
     assert.equal(runSsf(['config', '--resolve-model']).exitCode, 2);

--- a/tests/lib/cmd-config.test.mjs
+++ b/tests/lib/cmd-config.test.mjs
@@ -38,6 +38,13 @@ function runSsf(args) {
 }
 
 describe('ssf config --resolve-model', () => {
+  it('documents model profile resolution in CLI help', () => {
+    const result = runSsf(['--help']);
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.match(result.stdout, /config --resolve-model <profile>/);
+    assert.match(result.stdout, /without switching models/);
+  });
+
   it('prints configured model profile JSON', () => {
     writeConfig({ models: { mechanical: 'vendor-small' } });
     const result = runSsf(['config', '--resolve-model', 'mechanical']);

--- a/tests/lib/config-loader.test.mjs
+++ b/tests/lib/config-loader.test.mjs
@@ -44,6 +44,58 @@ describe('config-loader: getDefaults()', () => {
   });
 });
 
+describe('config-loader: resolveModelProfile()', () => {
+  let configLoader;
+
+  before(async () => {
+    const modulePath = join(process.cwd(), 'scripts/lib/config-loader.mjs');
+    configLoader = await import(modulePath);
+  });
+
+  it('exposes the supported model profiles in order', () => {
+    assert.deepStrictEqual(configLoader.MODEL_PROFILES, [
+      'mechanical', 'standard', 'strong', 'review',
+    ]);
+  });
+
+  it('resolves every configured profile without changing the model identifier', () => {
+    const config = {
+      models: {
+        mechanical: 'vendor-small', standard: 'vendor-standard',
+        strong: 'vendor-strong', review: 'vendor-review',
+      },
+    };
+    assert.deepStrictEqual(configLoader.resolveModelProfile(config, 'mechanical'), {
+      profile: 'mechanical', model: 'vendor-small', configured: true,
+    });
+    assert.deepStrictEqual(configLoader.resolveModelProfile(config, 'review'), {
+      profile: 'review', model: 'vendor-review', configured: true,
+    });
+  });
+
+  it('returns an explicit unmapped result for a known profile', () => {
+    assert.deepStrictEqual(configLoader.resolveModelProfile({}, 'strong'), {
+      profile: 'strong', model: null, configured: false,
+    });
+  });
+
+  it('does not let partial model mappings affect missing known profiles', () => {
+    assert.deepStrictEqual(
+      configLoader.resolveModelProfile({ models: { review: 'vendor-review' } }, 'standard'),
+      { profile: 'standard', model: null, configured: false },
+    );
+  });
+
+  it('rejects unknown and malformed mappings deterministically', () => {
+    assert.throws(() => configLoader.resolveModelProfile({}, 'fast'),
+      /Unknown model profile 'fast'.*mechanical.*standard.*strong.*review/);
+    assert.throws(() => configLoader.resolveModelProfile({ models: { review: '   ' } }, 'review'),
+      /models\.review must be a non-empty string/);
+    assert.throws(() => configLoader.resolveModelProfile({ models: { review: 42 } }, 'review'),
+      /models\.review must be a non-empty string/);
+  });
+});
+
 describe('config-loader: loadConfig()', () => {
   let configLoader;
 

--- a/tests/lib/config-loader.test.mjs
+++ b/tests/lib/config-loader.test.mjs
@@ -58,7 +58,7 @@ describe('config-loader: resolveModelProfile()', () => {
     ]);
   });
 
-  it('resolves every configured profile without changing the model identifier', () => {
+  it('resolves all four configured profiles without changing their model identifiers', () => {
     const config = {
       models: {
         mechanical: 'vendor-small', standard: 'vendor-standard',
@@ -67,6 +67,12 @@ describe('config-loader: resolveModelProfile()', () => {
     };
     assert.deepStrictEqual(configLoader.resolveModelProfile(config, 'mechanical'), {
       profile: 'mechanical', model: 'vendor-small', configured: true,
+    });
+    assert.deepStrictEqual(configLoader.resolveModelProfile(config, 'standard'), {
+      profile: 'standard', model: 'vendor-standard', configured: true,
+    });
+    assert.deepStrictEqual(configLoader.resolveModelProfile(config, 'strong'), {
+      profile: 'strong', model: 'vendor-strong', configured: true,
     });
     assert.deepStrictEqual(configLoader.resolveModelProfile(config, 'review'), {
       profile: 'review', model: 'vendor-review', configured: true,

--- a/tests/lib/model-profiles-docs.test.mjs
+++ b/tests/lib/model-profiles-docs.test.mjs
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const PROFILES = ['mechanical', 'standard', 'strong', 'review'];
+const FILES = [
+  'skills/build-executor/SKILL.md',
+  'README.md',
+  'docs/README_en.md',
+  'CHANGELOG.md',
+];
+
+describe('model profile documentation', () => {
+  it('names every supported profile in all affected documentation', () => {
+    for (const file of FILES) {
+      const content = readFileSync(join(ROOT, file), 'utf8');
+      for (const profile of PROFILES) {
+        assert.match(content, new RegExp(`\\b${profile}\\b`), `${file} must name ${profile}`);
+      }
+    }
+  });
+
+  it('documents read-only resolution without automatic switching', () => {
+    const zh = readFileSync(join(ROOT, 'README.md'), 'utf8');
+    const en = readFileSync(join(ROOT, 'docs/README_en.md'), 'utf8');
+    assert.match(zh, /--resolve-model/);
+    assert.match(zh, /不切换当前会话模型/);
+    assert.match(en, /--resolve-model/);
+    assert.match(en, /does not switch models/);
+  });
+});


### PR DESCRIPTION
Closes #37

Adds four platform-neutral model profiles with deterministic read-only resolution. No platform adapter, automatic model switching, or runtime dependency.