### PR TITLE
feat: support Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     if: "!startsWith(github.ref, 'refs/tags/')"
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -26,6 +26,11 @@ jobs:
       - run: npm test
       - name: Check version consistency
         run: node scripts/check-version-consistency.mjs
+      - name: CLI smoke
+        run: |
+          node scripts/spec-superflow.mjs doctor
+          node scripts/spec-superflow.mjs --version
+          node scripts/spec-superflow.mjs config --get execution.inlineThreshold
       - name: Token efficiency lint (warning only)
         run: node scripts/lint/lint-skills.mjs --include token
         continue-on-error: true
@@ -34,11 +39,14 @@ jobs:
     name: Platform Install Smoke (8 platforms)
     runs-on: ubuntu-latest
     if: "!startsWith(github.ref, 'refs/tags/')"
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
       - name: Smoke test all 8 platform installers (--local)
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ npm run build
 # Run integration tests
 npm test
 
-# Run single test (Node 22+ native test runner)
-node --test --experimental-strip-types tests/e2e.test.ts --test-name-pattern="parseDeltaSpec"
+# Run single test (Node 20+ native test runner)
+node --test tests/e2e.test.mjs --test-name-pattern="parseDeltaSpec"
 
 # Validate artifacts (uses docs/examples/ data)
 npm run validate
@@ -120,7 +120,7 @@ exploring → specifying → bridging → approved-for-build → executing → c
 
 ## CI/CD (`.github/workflows/ci.yml`)
 
-- **Push/PR to `main`**: Build + test on Node 22 + Plugin Scanner
+- **Push/PR to `main`**: Build + test on a Node 20/22 matrix + Plugin Scanner
 - **Tag push `v*`**: Build + test → `gh release create` → `npm publish --provenance --access public`
 - Release requires `NPM_TOKEN` secret and `id-token: write` permission for provenance
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "node --test --experimental-strip-types tests/e2e.test.ts tests/lib/*.test.*",
+    "test": "node --test tests/e2e.test.mjs tests/lib/*.test.mjs",
     "validate": "node scripts/validate-artifacts",
     "version": "node scripts/spec-superflow.mjs version $npm_new_version && node scripts/check-version-consistency.mjs && git add -A",
     "check-versions": "node scripts/check-version-consistency.mjs",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/MageByte-Zero/spec-superflow"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "devDependencies": {
     "typescript": "^6.0.3"

--- a/scripts/lib/cmd-doctor.mjs
+++ b/scripts/lib/cmd-doctor.mjs
@@ -125,12 +125,12 @@ function checkRootPluginAuthor(root) {
   return { pass: false, message: 'author object must contain a name property' };
 }
 
-function checkNodeVersion() {
-  const major = parseInt(process.version.slice(1).split('.')[0], 10);
-  if (major >= 22) {
-    return { pass: true, message: `${process.version}` };
+function checkNodeVersion(version = process.version) {
+  const major = parseInt(version.slice(1).split('.')[0], 10);
+  if (major >= 20) {
+    return { pass: true, message: version };
   }
-  return { pass: false, message: `${process.version} (requires >= 22)` };
+  return { pass: false, message: `${version} (requires >= 20)` };
 }
 
 function checkDocs(root) {

--- a/tests/e2e.test.mjs
+++ b/tests/e2e.test.mjs
@@ -15,7 +15,7 @@ import {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const EXAMPLES_DIR = resolve(__dirname, '../docs/examples');
 
-function readExample(...parts: string[]): string {
+function readExample(...parts) {
   return readFileSync(resolve(EXAMPLES_DIR, ...parts), 'utf-8');
 }
 
@@ -145,8 +145,8 @@ describe('Validator.validateImplementation', () => {
     );
     const completeness = report.dimensions.find(d => d.name === 'Completeness');
     assert.ok(completeness);
-    assert.equal(completeness!.status, 'FAIL');
-    assert.ok(completeness!.findings.some(f => f.message.includes('Rate limiting')));
+    assert.equal(completeness.status, 'FAIL');
+    assert.ok(completeness.findings.some(f => f.message.includes('Rate limiting')));
   });
 
   it('detects placeholder markers in diff (Correctness FAIL)', () => {
@@ -156,7 +156,7 @@ describe('Validator.validateImplementation', () => {
       '## Decisions\n### Decision 1\n- Choice: JWT\n- Rationale: stateless'
     );
     const correctness = report.dimensions.find(d => d.name === 'Correctness');
-    assert.equal(correctness!.status, 'FAIL');
+    assert.equal(correctness.status, 'FAIL');
   });
 
   it('passes when all requirements covered and no placeholders', () => {
@@ -175,7 +175,7 @@ describe('Validator.validateImplementation', () => {
       '## Decisions\n### Decision 1\n- Choice: JWT-based auth\n- Rationale: stateless'
     );
     const coherence = report.dimensions.find(d => d.name === 'Coherence');
-    assert.ok(coherence!.findings.length > 0);
+    assert.ok(coherence.findings.length > 0);
   });
 
   it('verifies Chinese spec content with Chinese tokenizer', () => {
@@ -186,7 +186,7 @@ describe('Validator.validateImplementation', () => {
     );
     const completeness = report.dimensions.find(d => d.name === 'Completeness');
     assert.ok(completeness, 'Missing Completeness dimension');
-    assert.equal(completeness!.status, 'PASS', `Expected PASS but got ${completeness!.status}: ${JSON.stringify(completeness!.findings)}`);
+    assert.equal(completeness.status, 'PASS', `Expected PASS but got ${completeness.status}: ${JSON.stringify(completeness.findings)}`);
   });
 
   it('detects missing requirement in Chinese spec (Completeness FAIL)', () => {
@@ -196,8 +196,8 @@ describe('Validator.validateImplementation', () => {
       '## Decisions\n### Decision 1\n- Choice: 令牌桶算法\n- Rationale: 平滑限流'
     );
     const completeness = report.dimensions.find(d => d.name === 'Completeness');
-    assert.equal(completeness!.status, 'FAIL');
-    assert.ok(completeness!.findings.some(f => f.message.includes('速率限制')));
+    assert.equal(completeness.status, 'FAIL');
+    assert.ok(completeness.findings.some(f => f.message.includes('速率限制')));
   });
 });
 

--- a/tests/lib/cmd-doctor.test.mjs
+++ b/tests/lib/cmd-doctor.test.mjs
@@ -307,15 +307,21 @@ describe('cmd-doctor: checkNodeVersion()', () => {
     checkNodeVersion = mod.checkNodeVersion;
   });
 
-  it('reports current Node.js version', () => {
+  it('accepts Node 20 as the minimum supported runtime', () => {
+    const result = checkNodeVersion('v20.0.0');
+    assert.equal(result.pass, true);
+    assert.equal(result.message, 'v20.0.0');
+  });
+
+  it('rejects Node 19 with the Node 20 repair guidance', () => {
+    const result = checkNodeVersion('v19.9.0');
+    assert.equal(result.pass, false);
+    assert.match(result.message, /v19\.9\.0 \(requires >= 20\)/);
+  });
+
+  it('checks the current Node.js version when no version is supplied', () => {
     const result = checkNodeVersion();
-    // Should pass on Node >= 22 (required by CLAUDE.md)
-    assert.ok(result.message.includes('v'));
-    // In CI/current env with Node 22+, it should pass
-    const major = parseInt(process.version.slice(1).split('.')[0], 10);
-    if (major >= 22) {
-      assert.equal(result.pass, true);
-    }
+    assert.ok(result.message.includes(process.version));
   });
 });
 

--- a/tests/lib/node20-compatibility.test.mjs
+++ b/tests/lib/node20-compatibility.test.mjs
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = file => readFileSync(join(ROOT, file), 'utf8');
+
+describe('Node 20 compatibility contract', () => {
+  it('declares Node 20 in package metadata and lockfile', () => {
+    const pkg = JSON.parse(read('package.json'));
+    const lock = JSON.parse(read('package-lock.json'));
+    assert.equal(pkg.engines.node, '>=20');
+    assert.equal(lock.packages[''].engines.node, '>=20');
+  });
+
+  it('runs build, test, doctor, CLI smoke, and installers on Node 20 and 22', () => {
+    const ci = read('.github/workflows/ci.yml');
+    assert.equal((ci.match(/node-version: \[20, 22\]/g) || []).length, 2);
+    assert.match(ci, /- run: npm run build/);
+    assert.match(ci, /- run: npm test/);
+    assert.match(ci, /node scripts\/spec-superflow\.mjs doctor/);
+    assert.match(ci, /node scripts\/spec-superflow\.mjs --version/);
+    assert.match(ci, /config --get execution\.inlineThreshold/);
+    assert.match(ci, /node-version: 22\n          registry-url:/);
+  });
+
+  it('keeps project guidance aligned with the Node 20 test command', () => {
+    const guide = read('AGENTS.md');
+    assert.match(guide, /Node 20\+ native test runner/);
+    assert.match(guide, /tests\/e2e\.test\.mjs/);
+    assert.doesNotMatch(guide, /experimental-strip-types/);
+  });
+});

--- a/tests/lib/node20-compatibility.test.mjs
+++ b/tests/lib/node20-compatibility.test.mjs
@@ -5,6 +5,11 @@ import { join } from 'node:path';
 
 const ROOT = process.cwd();
 const read = file => readFileSync(join(ROOT, file), 'utf8');
+const ciJob = (ci, name, nextName) => {
+  const start = ci.indexOf(`  ${name}:`);
+  const end = nextName ? ci.indexOf(`  ${nextName}:`, start) : ci.length;
+  return ci.slice(start, end);
+};
 
 describe('Node 20 compatibility contract', () => {
   it('declares Node 20 in package metadata and lockfile', () => {
@@ -12,17 +17,51 @@ describe('Node 20 compatibility contract', () => {
     const lock = JSON.parse(read('package-lock.json'));
     assert.equal(pkg.engines.node, '>=20');
     assert.equal(lock.packages[''].engines.node, '>=20');
+    assert.equal(lock.packages['node_modules/typescript'].engines.node, '>=14.17');
+  });
+
+  it('isolates CI jobs so adjacent runtime settings cannot satisfy a job contract', () => {
+    const fixture = `  build-and-test:
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/setup-node
+        with:
+          node-version: 22
+  platform-install-smoke:
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/setup-node
+        with:
+          node-version: \${{ matrix.node-version }}`;
+
+    assert.doesNotMatch(
+      ciJob(fixture, 'build-and-test', 'platform-install-smoke'),
+      /node-version: \$\{\{ matrix\.node-version \}\}/,
+    );
   });
 
   it('runs build, test, doctor, CLI smoke, and installers on Node 20 and 22', () => {
     const ci = read('.github/workflows/ci.yml');
-    assert.equal((ci.match(/node-version: \[20, 22\]/g) || []).length, 2);
-    assert.match(ci, /- run: npm run build/);
-    assert.match(ci, /- run: npm test/);
-    assert.match(ci, /node scripts\/spec-superflow\.mjs doctor/);
-    assert.match(ci, /node scripts\/spec-superflow\.mjs --version/);
-    assert.match(ci, /config --get execution\.inlineThreshold/);
-    assert.match(ci, /node-version: 22\n          registry-url:/);
+    const build = ciJob(ci, 'build-and-test', 'platform-install-smoke');
+    const platform = ciJob(ci, 'platform-install-smoke', 'release');
+    const release = ciJob(ci, 'release');
+
+    for (const job of [build, platform]) {
+      assert.match(job, /node-version: \[20, 22\]/);
+      assert.match(job, /node-version: \$\{\{ matrix\.node-version \}\}/);
+    }
+
+    assert.match(build, /- run: npm run build/);
+    assert.match(build, /- run: npm test/);
+    assert.match(build, /run: node scripts\/check-version-consistency\.mjs/);
+    assert.match(build, /node scripts\/spec-superflow\.mjs doctor/);
+    assert.match(build, /node scripts\/spec-superflow\.mjs --version/);
+    assert.match(build, /config --get execution\.inlineThreshold/);
+    assert.match(release, /node-version: 22\n          registry-url:/);
   });
 
   it('keeps project guidance aligned with the Node 20 test command', () => {

--- a/tests/lib/node20-test-entry.test.mjs
+++ b/tests/lib/node20-test-entry.test.mjs
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8'));
+
+describe('Node 20 test entry', () => {
+  it('runs only ESM JavaScript test files without strip-types', () => {
+    assert.match(pkg.scripts.test, /tests\/e2e\.test\.mjs/);
+    assert.match(pkg.scripts.test, /tests\/lib\/\*\.test\.mjs/);
+    assert.doesNotMatch(pkg.scripts.test, /experimental-strip-types/);
+    assert.equal(existsSync(join(ROOT, 'tests', 'e2e.test.mjs')), true);
+    assert.equal(existsSync(join(ROOT, 'tests', 'e2e.test.ts')), false);
+  });
+});


### PR DESCRIPTION
Closes #36

Adds verified Node 20/22 CI coverage, a Node 20-safe test entry, and aligned engines/doctor guidance. Release remains on Node 22.