### PR TITLE
feat: add minimality discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format loosely follows Keep a Changelog.
 ### Added
 
 - **#37 — Model profiles**：可在 `spec-superflow.config.json` 中为 `mechanical`、`standard`、`strong`、`review` 配置平台模型 ID，并用 `ssf config --resolve-model <profile>` 只读解析；不执行跨平台自动模型切换，也不新增 runtime dependency。
+- **#38 — Minimality discipline**：code-reviewer 现要求用任务依据审查无请求的依赖、配置、抽象与无关重构；保留 TDD、验证、安全和错误处理，不引入 Ponytail 或任何 runtime dependency。
 
 ## [0.8.17] - 2026-07-10
 

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -18,6 +18,12 @@ Two responsibilities: requesting review (dispatching a reviewer subagent) and re
 3. Fill placeholders: `[DESCRIPTION]` (what was built), `[PLAN_OR_REQUIREMENTS]` (contract/spec reference), `[BASE_SHA]`, `[HEAD_SHA]`
 4. Act on feedback: fix Critical immediately, fix Important before proceeding, note Minor for later, push back with reasoning if reviewer is wrong
 
+### Minimality And Scope
+
+For unrequested complexity, cite the missing task requirement and diff line.
+Use Important for merge-blocking complexity and Minor for safe,
+behavior-neutral redundancy; never score by line count.
+
 ## Part 2: Receiving Review Feedback
 
 ### The Response Pattern

--- a/skills/code-reviewer/code-reviewer-prompt.md
+++ b/skills/code-reviewer/code-reviewer-prompt.md
@@ -41,6 +41,12 @@ Subagent (general-purpose):
     - Are deviations justified improvements, or problematic departures?
     - Is all planned functionality present?
 
+    ## Minimality And Scope
+
+    For every unrequested dependency, configuration surface, abstraction, or unrelated refactor, cite the missing task requirement and diff line. Treat
+    merge-blocking complexity as Important and behavior-neutral redundancy as Minor. Do not use line count as evidence, and do not recommend removing
+    required tests, validation, security, or error handling.
+
     **Code quality:**
     - Clean separation of concerns?
     - Proper error handling?

--- a/tests/lib/minimality-discipline.test.mjs
+++ b/tests/lib/minimality-discipline.test.mjs
@@ -1,0 +1,21 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const read = file => readFileSync(join(ROOT, file), 'utf8');
+
+describe('minimality discipline: broad reviewer', () => {
+  it('traces unrequested complexity to the missing requirement and diff line', () => {
+    const skill = read('skills/code-reviewer/SKILL.md');
+    const prompt = read('skills/code-reviewer/code-reviewer-prompt.md');
+    assert.match(skill, /## Minimality And Scope/);
+    assert.match(prompt, /## Minimality And Scope/);
+    assert.match(prompt, /unrequested dependency, configuration surface, abstraction, or unrelated refactor/);
+    assert.match(prompt, /missing task requirement and diff line/);
+    assert.match(prompt, /merge-blocking complexity as Important/);
+    assert.match(prompt, /behavior-neutral redundancy as Minor/);
+    assert.match(prompt, /Do not use line count as evidence/);
+  });
+});

--- a/tests/lib/minimality-discipline.test.mjs
+++ b/tests/lib/minimality-discipline.test.mjs
@@ -21,5 +21,6 @@ describe('minimality discipline: broad reviewer', () => {
     assert.match(prompt, /merge-blocking complexity as Important/);
     assert.match(prompt, /behavior-neutral redundancy as Minor/);
     assert.match(prompt, /Do not use line count as evidence/);
+    assert.match(prompt, /do not recommend removing\s+required tests, validation, security, or error handling/);
   });
 });

--- a/tests/lib/minimality-discipline.test.mjs
+++ b/tests/lib/minimality-discipline.test.mjs
@@ -23,4 +23,15 @@ describe('minimality discipline: broad reviewer', () => {
     assert.match(prompt, /Do not use line count as evidence/);
     assert.match(prompt, /do not recommend removing\s+required tests, validation, security, or error handling/);
   });
+
+  it('records #38 without adding a Ponytail dependency', () => {
+    const changelog = read('CHANGELOG.md');
+    const pkg = JSON.parse(read('package.json'));
+    const lock = JSON.parse(read('package-lock.json'));
+    assert.match(changelog, /#38/);
+    assert.match(changelog, /不引入 Ponytail 或任何 runtime dependency/);
+    assert.equal(pkg.dependencies?.ponytail, undefined);
+    assert.equal(pkg.devDependencies?.ponytail, undefined);
+    assert.equal(lock.packages['node_modules/ponytail'], undefined);
+  });
 });

--- a/tests/lib/minimality-discipline.test.mjs
+++ b/tests/lib/minimality-discipline.test.mjs
@@ -11,6 +11,10 @@ describe('minimality discipline: broad reviewer', () => {
     const skill = read('skills/code-reviewer/SKILL.md');
     const prompt = read('skills/code-reviewer/code-reviewer-prompt.md');
     assert.match(skill, /## Minimality And Scope/);
+    assert.match(skill, /missing task requirement and diff line/);
+    assert.match(skill, /Important for merge-blocking complexity/);
+    assert.match(skill, /Minor for safe/);
+    assert.match(skill, /never score by line count/);
     assert.match(prompt, /## Minimality And Scope/);
     assert.match(prompt, /unrequested dependency, configuration surface, abstraction, or unrelated refactor/);
     assert.match(prompt, /missing task requirement and diff line/);


### PR DESCRIPTION
Closes #38

## What changed
- Adds evidence-based minimality and scope rules to the broad code reviewer.
- Requires unrequested dependencies, configuration, abstractions, and unrelated refactors to cite the missing task requirement and diff line.
- Keeps necessary TDD, validation, security, and error handling out of removal recommendations.

## Why
Baseline pressure scenarios showed the broad reviewer accepted these kinds of out-of-scope changes as reasonable architecture.

## Validation
- `npm run build`
- `npm test` (315 passing)
- `node scripts/lint/lint-skills.mjs --include token`
- `npm run validate -- docs/examples/add-dark-mode`
- `npm run validate -- docs/examples/refactor-auth-boundary`

No Ponytail or runtime dependency was added.