### PR TITLE
chore: release v0.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.8.17",
+      "version": "0.9.0",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.8.17 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.9.0 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.8.17"
+    "version": "0.9.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.8.17"
+    "version": "0.9.0"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.8.17",
+      "version": "0.9.0",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-11
+
 ### Added
 
 - **#37 — Model profiles**：可在 `spec-superflow.config.json` 中为 `mechanical`、`standard`、`strong`、`review` 配置平台模型 ID，并用 `ssf config --resolve-model <profile>` 只读解析；不执行跨平台自动模型切换，也不新增 runtime dependency。

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.8.17 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.9.0 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.8.17**。
+当前发布版本：**v0.9.0**。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v0.8.17`
+- 当前版本：`v0.9.0`
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -126,7 +126,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.8.17`
+- Current: `v0.9.0`
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)
 - Changelog: [CHANGELOG.md](../CHANGELOG.md)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.8.17: conditional injection — detects artifacts, injects workflow-start pointer
+# v0.9.0: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Three platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.8.17.
+Current version: v0.9.0.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "0.8.17",
+      "version": "0.9.0",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.8.17",
+  "version": "0.9.0",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"


### PR DESCRIPTION
## Release v0.9.0

- Syncs all plugin manifests, package metadata, package lockfile, public version markers, and release documentation to `0.9.0`.
- Archives #37 model profiles and #38 minimality discipline under the 0.9.0 changelog entry.
- Does not add dependencies or alter runtime behavior.

## Verification
- `node scripts/check-version-consistency.mjs`
- `node scripts/spec-superflow.mjs version 0.9.0 --dry-run`
- `npm ci --ignore-scripts`
- `npm run build`
- `npm test` (315 passing)
- `node scripts/spec-superflow.mjs doctor`
- `node scripts/spec-superflow.mjs install-workbuddy --dry-run`
- token lint and both example validations

After this PR merges, tag `v0.9.0` on `main` to trigger the Release workflow.