### PR TITLE
docs: gate marketplace release delivery

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,7 +17,7 @@
 |------|------|------|------|
 | Claude Code | marketplace | `/plugin update` | `/plugin uninstall` |
 | Cursor | skills 目录 / GitHub 导入 / 一键脚本 | 重新运行脚本 | 删除 `.cursor/skills/` |
-| OpenAI Codex CLI | Plugin Directory / marketplace | `codex plugin update` | `codex plugin remove` |
+| OpenAI Codex CLI | Plugin Directory / marketplace | marketplace refresh + re-add | `codex plugin remove` |
 | OpenAI Codex App | Plugins 面板 / marketplace | CLI 更新后 App 面板启用 | App 面板禁用 |
 | GitHub Copilot CLI | marketplace | `copilot plugin update` | `copilot plugin uninstall` |
 | Gemini CLI | `gemini extensions install` | `gemini extensions update` | `gemini extensions uninstall` |
@@ -160,25 +160,38 @@ codex
 
 ```bash
 codex plugin marketplace add hashgraph-online/awesome-codex-plugins
+codex plugin add spec-superflow@awesome-codex-plugins
+```
+
+### 直接安装指定 release tag
+
+当社区 marketplace 镜像尚未同步时，可直接指定本仓库的 release tag：
+
+```bash
+codex plugin marketplace add MageByte-Zero/spec-superflow --ref v0.9.0
 codex plugin add spec-superflow@spec-superflow
 ```
+
+这条路径绕过社区镜像延迟。
 
 ### 升级
 
 ```bash
-codex plugin update spec-superflow
+codex plugin marketplace upgrade awesome-codex-plugins
+codex plugin add spec-superflow@awesome-codex-plugins
+codex plugin list | rg spec-superflow
 ```
 
 ### 卸载
 
 ```bash
-codex plugin remove spec-superflow
+codex plugin remove spec-superflow@awesome-codex-plugins
 ```
 
 ### 验证
 
 ```bash
-codex plugin list | grep spec-superflow
+codex plugin list | rg spec-superflow
 ```
 
 ---
@@ -197,7 +210,7 @@ Codex App 的主流方式是 **Plugins** 面板。仓库已提供 `.codex-plugin
 
 ```bash
 codex plugin marketplace add hashgraph-online/awesome-codex-plugins
-codex plugin add spec-superflow@spec-superflow
+codex plugin add spec-superflow@awesome-codex-plugins
 ```
 
 然后**重启 Codex App**，在 **Plugins** 面板中启用 `spec-superflow`。
@@ -205,10 +218,12 @@ codex plugin add spec-superflow@spec-superflow
 ### 升级
 
 ```bash
-codex plugin update spec-superflow
+codex plugin marketplace upgrade awesome-codex-plugins
+codex plugin add spec-superflow@awesome-codex-plugins
+codex plugin list | rg spec-superflow
 ```
 
-更新后重启 Codex App。
+更新后重启 Codex App 并新开会话；旧会话不会热加载 skills。
 
 ### 卸载
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,19 @@ codex
 
 # 或添加社区 marketplace 后安装
 codex plugin marketplace add hashgraph-online/awesome-codex-plugins
+codex plugin add spec-superflow@awesome-codex-plugins
+
+# 直接从指定 release tag 安装（不等待社区镜像同步）
+codex plugin marketplace add MageByte-Zero/spec-superflow --ref v0.9.0
 codex plugin add spec-superflow@spec-superflow
+
+# 升级并验证社区 marketplace 安装
+codex plugin marketplace upgrade awesome-codex-plugins
+codex plugin add spec-superflow@awesome-codex-plugins
+codex plugin list | rg spec-superflow
 ```
 
-Codex App 打开 **Plugins** 面板，安装或启用 `spec-superflow`。如果通过 CLI 安装，重启 App 后在 Plugins 面板启用。
+Codex App 打开 **Plugins** 面板，安装或启用 `spec-superflow`。通过 CLI 安装或升级后，重启 Codex App 并新开会话；旧会话不会热加载 skills。
 
 ### GitHub Copilot CLI
 
@@ -148,6 +157,7 @@ npx spec-superflow list          # 或通过 npx 使用
 ### 版本
 
 - 当前版本：`v0.9.0`
+- v0.9.0 highlights：支持 Node 20/22、model profiles 只读解析，以及 code-reviewer 的最小性审查；详见 [CHANGELOG.md](CHANGELOG.md)
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -49,6 +49,29 @@ For each example in `docs/examples/`:
 - `spec-superflow.config.json` absence still works (backward compatible defaults)
 - `package.json` `bin` field points to correct entry script
 
+## AI Agent Marketplace Delivery
+
+- Review `README.md`, `INSTALL.md`, and `CHANGELOG.md` so their installation, upgrade, and release messages match.
+- Verify external marketplace delivery instead of treating a tag or npm publish as completion:
+
+  ```bash
+  node scripts/verify-marketplace-release.mjs \
+    --manifest-url https://raw.githubusercontent.com/hashgraph-online/awesome-codex-plugins/main/plugins/MageByte-Zero/spec-superflow/.codex-plugin/plugin.json \
+    --expected-version <semver>
+  ```
+
+- Use one 干净 Codex configuration directory for marketplace add, plugin add, and plugin list:
+
+  ```bash
+  CODEX_HOME="$(mktemp -d)"
+  export CODEX_HOME
+  codex plugin marketplace add hashgraph-online/awesome-codex-plugins
+  codex plugin add spec-superflow@awesome-codex-plugins
+  codex plugin list | rg spec-superflow
+  ```
+
+- If the remote marketplace version lags, submit and track the 同步 PR; wait for maintainers to merge and the generator to finish, then rerun the delivery verification and clean-Codex installation check.
+
 ## Publishing Checks
 
 - there are no stray `TODO` or `TBD` markers

--- a/scripts/verify-marketplace-release.mjs
+++ b/scripts/verify-marketplace-release.mjs
@@ -1,0 +1,59 @@
+import { fileURLToPath } from 'node:url';
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+export function parseReleaseCheckArgs(args) {
+  if (args.length !== 4 || args[0] !== '--manifest-url' || args[2] !== '--expected-version') {
+    throw new Error('Usage: verify-marketplace-release --manifest-url <https-url> --expected-version <x.y.z>');
+  }
+  const parsedUrl = new URL(args[1]);
+  if (parsedUrl.protocol !== 'https:') throw new Error('manifest URL must use HTTPS');
+  if (!SEMVER.test(args[3])) throw new Error('expected version must use x.y.z semver');
+  return { manifestUrl: parsedUrl.href, expectedVersion: args[3] };
+}
+
+export async function verifyMarketplaceRelease({
+  manifestUrl,
+  expectedVersion,
+  fetchImpl = globalThis.fetch,
+}) {
+  let response;
+  try {
+    response = await fetchImpl(manifestUrl);
+  } catch (error) {
+    throw new Error('marketplace network request failed: ' + error.message);
+  }
+  if (!response.ok) throw new Error('marketplace manifest request failed: HTTP ' + response.status);
+  let manifest;
+  try {
+    manifest = await response.json();
+  } catch (error) {
+    throw new Error('marketplace manifest is not valid JSON: ' + error.message);
+  }
+  if (typeof manifest.version !== 'string') throw new Error('marketplace manifest is missing a string version');
+  if (manifest.version !== expectedVersion) {
+    throw new Error('marketplace version mismatch: expected ' + expectedVersion + ', found ' + manifest.version);
+  }
+  return { manifestUrl, expectedVersion, actualVersion: manifest.version };
+}
+
+export async function main(
+  args,
+  { fetchImpl = globalThis.fetch, stdout = process.stdout, stderr = process.stderr } = {},
+) {
+  try {
+    const { manifestUrl, expectedVersion } = parseReleaseCheckArgs(args);
+    const result = await verifyMarketplaceRelease({ manifestUrl, expectedVersion, fetchImpl });
+    stdout.write(`Marketplace manifest verified: ${result.actualVersion} (${result.manifestUrl})\n`);
+    return 0;
+  } catch (error) {
+    stderr.write(`Error: ${error.message}\n`);
+    return 1;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/tests/lib/marketplace-release-docs.test.mjs
+++ b/tests/lib/marketplace-release-docs.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = file => readFileSync(join(process.cwd(), file), 'utf8');
+
+describe('marketplace release documentation', () => {
+  it('uses the real Codex selectors and upgrade flow', () => {
+    for (const text of [read('README.md'), read('INSTALL.md')]) {
+      assert.match(text, /spec-superflow@awesome-codex-plugins/);
+      assert.match(text, /spec-superflow@spec-superflow/);
+      assert.match(text, /codex plugin marketplace upgrade awesome-codex-plugins/);
+      assert.doesNotMatch(text, /codex plugin update/);
+      assert.match(text, /codex plugin list/);
+    }
+  });
+
+  it('records v0.9.0 highlights and the external delivery gate', () => {
+    const readme = read('README.md');
+    const checklist = read('docs/release-checklist.md');
+    assert.match(readme, /v0\.9\.0/);
+    assert.match(readme, /Node 20/);
+    assert.match(readme, /model profiles/);
+    assert.match(readme, /最小性/);
+    assert.match(checklist, /AI Agent Marketplace Delivery/);
+    assert.match(checklist, /verify-marketplace-release/);
+    assert.match(checklist, /同步 PR/);
+    assert.match(checklist, /干净 Codex/);
+  });
+});

--- a/tests/lib/verify-marketplace-release.test.mjs
+++ b/tests/lib/verify-marketplace-release.test.mjs
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import {
+  main,
   parseReleaseCheckArgs,
   verifyMarketplaceRelease,
 } from '../../scripts/verify-marketplace-release.mjs';
@@ -42,6 +44,18 @@ describe('verify marketplace release', () => {
       () => verifyMarketplaceRelease({
         manifestUrl: 'https://example.test/plugin.json',
         expectedVersion: '0.9.0',
+        fetchImpl: async () => ({
+          ok: true,
+          status: 200,
+          async json() { throw new Error('unexpected token'); },
+        }),
+      }),
+      /marketplace manifest is not valid JSON: unexpected token/,
+    );
+    await assert.rejects(
+      () => verifyMarketplaceRelease({
+        manifestUrl: 'https://example.test/plugin.json',
+        expectedVersion: '0.9.0',
         fetchImpl: async () => { throw new Error('socket closed'); },
       }),
       /network request failed: socket closed/,
@@ -72,5 +86,43 @@ describe('verify marketplace release', () => {
       ]),
       /x\.y\.z/,
     );
+  });
+
+  it('writes exact success and error messages through injected streams', async () => {
+    const stdout = [];
+    const stderr = [];
+    const args = [
+      '--manifest-url', 'https://example.test/plugin.json',
+      '--expected-version', '0.9.0',
+    ];
+    const streams = {
+      stdout: { write: (message) => stdout.push(message) },
+      stderr: { write: (message) => stderr.push(message) },
+    };
+
+    assert.equal(await main(args, {
+      ...streams,
+      fetchImpl: async () => response(),
+    }), 0);
+    assert.deepEqual(stdout, ['Marketplace manifest verified: 0.9.0 (https://example.test/plugin.json)\n']);
+    assert.deepEqual(stderr, []);
+
+    assert.equal(await main(args, {
+      ...streams,
+      fetchImpl: async () => response({ body: { version: '0.8.17' } }),
+    }), 1);
+    assert.deepEqual(stderr, ['Error: marketplace version mismatch: expected 0.9.0, found 0.8.17\n']);
+  });
+
+  it('does not set process.exitCode when imported', () => {
+    const scriptUrl = new URL('../../scripts/verify-marketplace-release.mjs', import.meta.url).href;
+    const result = spawnSync(process.execPath, [
+      '--input-type=module',
+      '--eval',
+      `await import(${JSON.stringify(scriptUrl)}); if (process.exitCode !== undefined) throw new Error('process.exitCode was set');`,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stderr, '');
   });
 });

--- a/tests/lib/verify-marketplace-release.test.mjs
+++ b/tests/lib/verify-marketplace-release.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseReleaseCheckArgs,
+  verifyMarketplaceRelease,
+} from '../../scripts/verify-marketplace-release.mjs';
+
+const response = ({ ok = true, status = 200, body = { version: '0.9.0' } } = {}) => ({
+  ok,
+  status,
+  async json() { return body; },
+});
+
+describe('verify marketplace release', () => {
+  it('accepts a matching HTTPS manifest version', async () => {
+    const result = await verifyMarketplaceRelease({
+      manifestUrl: 'https://example.test/plugin.json',
+      expectedVersion: '0.9.0',
+      fetchImpl: async () => response(),
+    });
+    assert.equal(result.actualVersion, '0.9.0');
+  });
+
+  it('rejects HTTP, malformed, network, and version-drift responses', async () => {
+    await assert.rejects(
+      () => verifyMarketplaceRelease({
+        manifestUrl: 'https://example.test/plugin.json',
+        expectedVersion: '0.9.0',
+        fetchImpl: async () => response({ ok: false, status: 404 }),
+      }),
+      /HTTP 404/,
+    );
+    await assert.rejects(
+      () => verifyMarketplaceRelease({
+        manifestUrl: 'https://example.test/plugin.json',
+        expectedVersion: '0.9.0',
+        fetchImpl: async () => response({ body: { name: 'spec-superflow' } }),
+      }),
+      /missing a string version/,
+    );
+    await assert.rejects(
+      () => verifyMarketplaceRelease({
+        manifestUrl: 'https://example.test/plugin.json',
+        expectedVersion: '0.9.0',
+        fetchImpl: async () => { throw new Error('socket closed'); },
+      }),
+      /network request failed: socket closed/,
+    );
+    await assert.rejects(
+      () => verifyMarketplaceRelease({
+        manifestUrl: 'https://example.test/plugin.json',
+        expectedVersion: '0.9.0',
+        fetchImpl: async () => response({ body: { version: '0.8.17' } }),
+      }),
+      /expected 0.9.0, found 0.8.17/,
+    );
+  });
+
+  it('requires one HTTPS URL and one complete semver argument', () => {
+    assert.throws(() => parseReleaseCheckArgs([]), /Usage:/);
+    assert.throws(
+      () => parseReleaseCheckArgs([
+        '--manifest-url', 'http://example.test/plugin.json',
+        '--expected-version', '0.9.0',
+      ]),
+      /HTTPS/,
+    );
+    assert.throws(
+      () => parseReleaseCheckArgs([
+        '--manifest-url', 'https://example.test/plugin.json',
+        '--expected-version', '0.9',
+      ]),
+      /x\.y\.z/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- correct the public Codex Marketplace selector and replace the obsolete plugin update command
- document the release-tag install path, v0.9.0 highlights, and required app restart
- add a zero-dependency remote marketplace manifest-version verifier with focused tests
- add marketplace delivery gates to the release checklist, including upstream sync and a clean shared CODEX_HOME install

## Verification
- `npm run build`
- `npm test` (322 passing)
- `node scripts/lint/lint-skills.mjs --include token`
- `npm run validate -- docs/examples/add-dark-mode`
- `npm run validate -- docs/examples/refactor-auth-boundary`
- `node scripts/check-version-consistency.mjs`
- public marketplace manifest verifier against `hashgraph-online/awesome-codex-plugins` (0.9.0)

No version bump or release tag is included in this documentation/tooling correction.