### PR TITLE
fix(contract-builder): resolve deployed template path

### DIFF
--- a/skills/contract-builder/SKILL.md
+++ b/skills/contract-builder/SKILL.md
@@ -5,7 +5,7 @@ description: Convert approved planning artifacts into an execution contract. Inv
 
 # Contract Builder
 
-Converts planning artifacts into a single execution handshake: `execution-contract.md`. Use `templates/execution-contract.md` as the baseline structure.
+Converts planning artifacts into a single execution handshake: `execution-contract.md`. Use `${CLAUDE_PLUGIN_ROOT}/templates/execution-contract.md` as the baseline structure.
 
 Read before generating: `proposal.md`, `specs/`, `design.md`, `tasks.md`, `docs/artifact-contract.md`.
 

--- a/tests/lib/cmd-install-zcode.test.mjs
+++ b/tests/lib/cmd-install-zcode.test.mjs
@@ -29,4 +29,14 @@ describe('BUG/#29: install-zcode deploys skills', () => {
     assert.equal(content.includes('${CLAUDE_PLUGIN_ROOT}'), false, 'CLAUDE_PLUGIN_ROOT should be rewritten to an absolute path');
     assert.equal(existsSync(join(cwd, '.zcode', 'rules', 'phase-guard.mdc')), true, 'phase guard should be written');
   });
+
+  it('SHALL give contract-builder the deployed execution-contract template path', () => {
+    execSync(`node ${CLI} install-zcode --local "${ROOT}"`, { cwd, stdio: 'pipe', timeout: 60000 });
+
+    const templatePath = join(cwd, '.zcode', 'spec-superflow', 'templates', 'execution-contract.md');
+    const contractBuilder = readFileSync(join(cwd, '.zcode', 'skills', 'contract-builder', 'SKILL.md'), 'utf-8');
+
+    assert.equal(existsSync(templatePath), true, 'deployed template should exist');
+    assert.equal(contractBuilder.includes(templatePath), true, 'contract-builder should reference the deployed template');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #53 by referencing the execution-contract template through the installed plugin root instead of a skill-relative path.

## Root cause

Platform installers deploy skills and runtime files into separate directories. The previous relative path could not resolve the copied template after installation.

## Validation

- npm run build
- npm test (384 passing)
- npm run validate -- docs/examples/add-dark-mode