### PR TITLE
fix: make closing a true terminal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+### Fixed
+
+- **#64 — closing 终态生命周期对齐**：将 `release-archivist` 验证、`spec-merger` 同步和归档确认明确为 `executing` 内的 pre-closing 收尾步骤；`closing` 是 `CLOSED` 成功终态，且没有 next skill。
+
 ## [0.10.0] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ command 尚未实现，不能据此假定存在 `/ssf:*` 命令。
 | 5 | `build-executor` | 执行 | TDD 铁律 + SDD 子代理驱动 + Review Gate |
 | 6 | `bug-investigator` | 调试 | 4 阶段根因分析，3+ 修复失败 → 质疑架构 |
 | 7 | `code-reviewer` | 审查 | 结构化审查，三级问题分级 |
-| 8 | `release-archivist` | 收口 | 验证前完成铁律 + 归档 + 风险总结 |
-| 9 | `spec-merger` | 同步 | Delta Spec → 主规范智能合并 |
+| 8 | `release-archivist` | 执行内收尾 | 验证前完成铁律 + 归档 + 风险总结 |
+| 9 | `spec-merger` | 执行内收尾 | Delta Spec → 主规范智能合并 |
 
 ---
 
@@ -302,10 +302,12 @@ command 尚未实现，不能据此假定存在 `/ssf:*` 命令。
    executing          build-executor: TDD → SDD → Review Gate
        │
        ├──[bug]──→ debugging  → bug-investigator
+       │
        ▼
-   closing            release-archivist 验证 + 归档
+   pre-closing（仍属于 executing 的收尾步骤，不是新增状态）
+       │ release-archivist 验证 → spec-merger 同步 → 归档确认
        ▼
-   syncing            spec-merger（delta spec → 主规范）
+   closing            CLOSED 成功终态（无 next skill）
 ```
 
 **关键约束：** 没有 `execution-contract.md` 或未被批准 → 不允许实现；full/hotfix 没有 current execution plan、或任一 wave 缺少 `pass` review receipt → 不允许推进；需求变更 → 强制回退；遇到 bug → 强制走 debugging，不允许"随便试试"。

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -197,8 +197,8 @@ AI coding sessions fail in one of two ways:
 | 5 | `build-executor` | Executing | TDD Iron Law + SDD subagent-driven + Review Gates |
 | 6 | `bug-investigator` | Debugging | 4-phase root cause analysis; 3+ failures → escalate |
 | 7 | `code-reviewer` | Review | Structured review with 3-level severity classification |
-| 8 | `release-archivist` | Closing | Verification-before-completion + archive + risk summary |
-| 9 | `spec-merger` | Syncing | Delta spec → main spec merge with conflict detection |
+| 8 | `release-archivist` | Pre-closing within executing | Verification-before-completion + archive + risk summary |
+| 9 | `spec-merger` | Pre-closing within executing | Delta spec → main spec merge with conflict detection |
 
 ---
 
@@ -223,10 +223,12 @@ You: "add authorization to the API"
    executing          build-executor: TDD → SDD → Review Gate
        │
        ├──[bug]──→ debugging  → bug-investigator
+       │
        ▼
-   closing            release-archivist: verify + archive
+   pre-closing (a wrap-up step within executing, not a ninth state)
+       │ release-archivist verifies → spec-merger sync → archive confirmation
        ▼
-   syncing            spec-merger (delta specs → main specs)
+   closing            CLOSED successful terminal state (no next skill)
 ```
 
 **Hard constraints:** No `execution-contract.md` or no approval → implementation blocked. Requirements change mid-execution → forced rollback. Bug encountered → must enter debugging state, no ad-hoc fixes.

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -121,7 +121,9 @@ eight core states.
                 |              +------------------------------------+
                 |              (contract drift → re-bridge)
                 +---------------------------------------------------+
-                     (scope change → re-specify)
+                     (scope change in a non-terminal state → re-specify)
+
+  closing ─── scope change ───> create new change
 
   (any non-terminal state) ──> abandoned
                                 (terminal, no further transitions)

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -38,6 +38,7 @@
 - TDD, SDD (subagent-driven), review gates, and escalation rules apply
 - `build-executor` is active
 - `code-reviewer` invoked after each execution batch
+- 发布验证、delta-spec 同步与审计都必须在此状态完成；必要时调用 `release-archivist` 和 `spec-merger`，再执行最终状态转换
 
 ## Execution Plan Control Plane
 
@@ -72,11 +73,10 @@ slash commands are not implemented; do not assume `/ssf:*` commands exist.
 
 ### `closing`
 
-- verification is complete with evidence
-- `release-archivist` is active
-- `verification-before-completion` gate enforced
-- `spec-merger` invoked if delta specs need merging into main specs
-- the change can be summarized, archived, or handed off
+- successful terminal state（成功终态）；验证、同步和审计证据已在 `executing` 完成
+- 没有 active skill，next skill 为 `none`
+- 进入后不运行 handoff、checkpoint 或 execution-control 恢复扫描，也不再路由 `release-archivist` 或 `spec-merger`
+- 不允许继续、恢复、交接或发生任何后续状态转换
 
 ### `abandoned`
 
@@ -87,7 +87,7 @@ slash commands are not implemented; do not assume `/ssf:*` commands exist.
 
 ## Terminal States
 
-- `closing` — successful completion with verification
+- `closing` — successful terminal completion；所有收尾动作均在 `executing` 完成后才可进入
 - `abandoned` — change abandoned (no delta spec merge, no further transitions allowed)
 
 ## Recovery Overlays
@@ -100,9 +100,9 @@ eight core states.
   recovery context under `.superpowers/sdd/checkpoints/`.
 - `ssf handoff create <change-dir> --type <type> ...` creates explicit side-work
   contracts under `.superpowers/sdd/handoffs/`.
-- `workflow-start` lists overlays before normal routing. `result-ready` handoffs
-  require explicit review and resolution before affected work resumes; stale
-  checkpoints remain historical evidence only.
+- `workflow-start` 仅对非终态在正常路由前列出 overlays；`closing` 会在
+  overlay recovery 前短路。`result-ready` handoff 在受影响工作恢复前仍需显式
+  审查和 resolve；stale checkpoint 仅保留为历史证据。
 - Prototype work is optional and requires explicit user confirmation. Results
   are reviewed manually and never mutate `design.md` or `tasks.md`.
 

--- a/scripts/guard/guard.mjs
+++ b/scripts/guard/guard.mjs
@@ -37,7 +37,6 @@ const TRANSITION_CHECKS = {
   'approved-for-build:bridging':    [],
   'executing:specifying':           [],
   'executing:bridging':             [],
-  'closing:specifying':             [],
 
   // Abandon transitions (terminal)
   'exploring:abandoned':            [],

--- a/scripts/lib/cmd-inject.mjs
+++ b/scripts/lib/cmd-inject.mjs
@@ -110,19 +110,11 @@ const PHASE_TEMPLATES = {
 
 **当前阶段**: {{state}} | **工作流**: {{workflow}}
 
-## ✅ 允许操作
-- 运行验证（三维验证）
-- 归档变更
-- 合并 delta specs
-
-## ⛔ 禁止操作
-- 修改 execution-contract.md
-- 执行新任务
-- 修改 proposal.md, specs/, design.md
-
-## 🔔 决策点
-- DP-6: 验证失败 — 验证未通过时需用户决定
-- DP-7: 归档确认 — 需用户确认归档`,
+## ⛔ 终止状态
+- 此变更已成功关闭；验证、规范同步和归档确认均已完成
+- 不允许任何进一步操作或状态转换
+- 不得重跑实现、验证、归档或 delta spec 合并
+- 恢复时只报告 CLOSED；next skill 为 none`,
 
   'abandoned': `# Phase Guard: {{change_name}}
 

--- a/skills/release-archivist/SKILL.md
+++ b/skills/release-archivist/SKILL.md
@@ -104,8 +104,8 @@ Complete every release, delta-spec synchronization, and audit action while the
 state remains `executing`. If delta specs exist, invoke `spec-merger` and
 resolve its outcome before the final `executing → closing` transition. Then
 run `npx --yes --package spec-superflow@0.10.0 ssf state transition <change-dir> closing`.
-`executing → closing` is the final action: once it succeeds, do not route to a
-next skill or run recovery scans.
+`executing → closing` is the final action: once it succeeds, select no next
+skill and run no recovery scans.
 
 ## Lightweight Closure (hotfix/tweak)
 

--- a/skills/release-archivist/SKILL.md
+++ b/skills/release-archivist/SKILL.md
@@ -5,7 +5,9 @@ description: Close out a spec-superflow change with verification, summary, and a
 
 # Release Archivist
 
-Finish a spec-superflow change cleanly with verification evidence.
+Finish a spec-superflow change cleanly with verification evidence. This skill
+operates while the change state is `executing`; it is not an active skill after
+the final transition to `closing`.
 
 ## The Iron Law: Verification Before Completion
 
@@ -87,9 +89,14 @@ Verify DP-0 through DP-6 are recorded before DP-7.
 
 If implementation diverged from the contract, return to `bridging` before closure.
 
-## Post-Verification
+## Finalize While Executing
 
-Run `npx --yes --package spec-superflow@0.10.0 ssf state transition <change-dir> closing`. If delta specs exist, route to `spec-merger`.
+Complete every release, delta-spec synchronization, and audit action while the
+state remains `executing`. If delta specs exist, invoke `spec-merger` and
+resolve its outcome before the final `executing → closing` transition. Then
+run `npx --yes --package spec-superflow@0.10.0 ssf state transition <change-dir> closing`.
+`executing → closing` is the final action: once it succeeds, do not route to a
+next skill or run recovery scans.
 
 ## Lightweight Closure (hotfix/tweak)
 

--- a/skills/release-archivist/SKILL.md
+++ b/skills/release-archivist/SKILL.md
@@ -9,6 +9,15 @@ Finish a spec-superflow change cleanly with verification evidence. This skill
 operates while the change state is `executing`; it is not an active skill after
 the final transition to `closing`.
 
+## Execution-State Guard
+
+Before verification, `ssf audit`, any DP state write, or delta-spec merge, run
+`npx --yes --package spec-superflow@0.10.0 ssf state get <change-dir> state`.
+Continue only when the persisted state is exactly `executing`. If it is
+`closing` → STOP: "Closing is terminal; release, audit, and archival work were
+completed before this transition." For any other state, or if the state cannot
+be read → STOP and route through `workflow-start`; do not perform side effects.
+
 ## The Iron Law: Verification Before Completion
 
 Claiming work is complete without verification is dishonesty, not efficiency. Before claiming any status:

--- a/skills/spec-merger/SKILL.md
+++ b/skills/spec-merger/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: spec-merger
-description: Sync delta specs to main specs after closure. Invoke when a change is closing, delta specs need merging into the main spec base, or when detecting spec drift across multiple changes.
+description: Sync delta specs to main specs before closure. Invoke while an executing change has delta specs to merge into the main spec base, or when detecting spec drift across multiple changes.
 ---
 
 # Spec Merger
 
-After a change completes, delta specs (ADDED/MODIFIED/REMOVED/RENAMED) must be merged into the main spec base. **Specs that aren't synced become lies.**
+Before the final `executing → closing` transition, delta specs (ADDED/MODIFIED/REMOVED/RENAMED) must be merged into the main spec base. **Specs that aren't synced become lies.** A change already in `closing` must not be routed to `spec-merger`.
 
 ## Pre-Flight Checks
 
@@ -14,6 +14,9 @@ Run `npx --yes --package spec-superflow@0.10.0 ssf sync <change-dir>`. If confli
 
 ### Abandoned Change Guard
 Check if the change is `abandoned`. If so → STOP: "Abandoned changes cannot be synced. Delta specs are preserved for reference but must not be merged."
+
+### Closing Change Guard
+Check if the change is `closing`. If so → STOP: "Closing is terminal. Do not route this change to spec-merger; synchronization belongs before the final executing → closing transition."
 
 ## Sync Process
 

--- a/skills/spec-merger/SKILL.md
+++ b/skills/spec-merger/SKILL.md
@@ -7,16 +7,20 @@ description: Sync delta specs to main specs before closure. Invoke while an exec
 
 Before the final `executing → closing` transition, delta specs (ADDED/MODIFIED/REMOVED/RENAMED) must be merged into the main spec base. **Specs that aren't synced become lies.** A change already in `closing` must not be routed to `spec-merger`.
 
+## Execution-State Guard
+
+Before `ssf sync` or any other write, run
+`npx --yes --package spec-superflow@0.10.0 ssf state get <change-dir> state`.
+Continue only when the persisted state is exactly `executing`. If it is
+`closing` → STOP: "Closing is terminal. Do not route this change to spec-merger;
+synchronization belongs before the final executing → closing transition." For
+any other state, or if the state cannot be read → STOP and route through
+`workflow-start`; do not perform side effects.
+
 ## Pre-Flight Checks
 
 ### Conflict Detection
 Run `npx --yes --package spec-superflow@0.10.0 ssf sync <change-dir>`. If conflicts are detected (same requirement modified by multiple changes), present the conflict list to the user for resolution order.
-
-### Abandoned Change Guard
-Check if the change is `abandoned`. If so → STOP: "Abandoned changes cannot be synced. Delta specs are preserved for reference but must not be merged."
-
-### Closing Change Guard
-Check if the change is `closing`. If so → STOP: "Closing is terminal. Do not route this change to spec-merger; synchronization belongs before the final executing → closing transition."
 
 ## Sync Process
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -17,12 +17,26 @@ Do NOT invoke for: general coding tasks outside spec-superflow changes, casual q
 
 `exploring` → `specifying` → `bridging` → `approved-for-build` → `executing` → `closing`, with `debugging` side-path from `executing`, and `abandoned` as terminal. If a transition is ambiguous, run `npx --yes --package spec-superflow@0.10.0 ssf runtime asset read docs/state-machine.md`.
 
+## Terminal-State Short Circuit
+
+Before update checks or recovery overlays, inspect the persisted state. If it is
+`closing`, stop immediately: `closing` is a successful terminal state and the
+next skill is `none`. Report the terminal state and its persisted evidence.
+Do not run `handoff list`, `checkpoint list`, the execution-control recovery
+scan, or `release-archivist`; do not resume, hand off, or route any more work.
+
 ## Initialization
 
 1. **Update check**: Run `npx --yes --package spec-superflow@0.10.0 ssf runtime check-update`. Exit 0 → continue. Exit 1 → non-blocking upgrade reminder. Exit 2 → skip.
 2. **Inspect change folder**: Check for `proposal.md`, `specs/`, `design.md`, `tasks.md`, `execution-contract.md`. Answer: Is the change fuzzy? Artifacts missing/unstable? Contract exist? User approved contract? Execution in progress or blocked? In verification/wrap-up?
+
+## Overlay Recovery Scan
+
 3. **Overlay recovery scan**: Run `npx --yes --package spec-superflow@0.10.0 ssf handoff list <change-dir> --json` and `npx --yes --package spec-superflow@0.10.0 ssf checkpoint list <change-dir> --json`. A `result-ready` handoff requires explicit review and `npx --yes --package spec-superflow@0.10.0 ssf handoff resolve` before resuming the affected work. An `active` handoff is non-blocking side work. Show a non-stale checkpoint as recovery context; show a stale checkpoint only as historical evidence.
-4. **Execution-control recovery scan**: For `approved-for-build`, `executing`, `debugging`, or `closing`, run `npx --yes --package spec-superflow@0.10.0 ssf execution show <change-dir> --json`. Treat only `current: true` plus `waves[].eligible: true` as permission to start a wave; report plan revision, mode, next eligible wave, and every wave's receipt/blockers. A missing, invalid, or stale plan blocks implementation and routes to `build-executor`; do not infer progress from chat history.
+
+## Execution-Control Recovery Scan
+
+4. **Execution-control recovery scan**: For `approved-for-build`, `executing`, or `debugging`, run `npx --yes --package spec-superflow@0.10.0 ssf execution show <change-dir> --json`. Treat only `current: true` plus `waves[].eligible: true` as permission to start a wave; report plan revision, mode, next eligible wave, and every wave's receipt/blockers. A missing, invalid, or stale plan blocks implementation and routes to `build-executor`; do not infer progress from chat history.
 
 ## DP-0: User Confirmation Gate
 
@@ -67,10 +81,10 @@ Execution hit blockage: test failure, unexpected behavior, build error, task can
 The current planned wave is implemented and ready for spec-compliance + code-quality verification. A reviewer must write an `npx --yes --package spec-superflow@0.10.0 ssf execution review <change-dir> --wave <id> --base <sha> --head <sha> --report <path> --verdict <pass|fail>` receipt before any dependent wave or closing transition.
 
 ### Route to release-archivist
-Guard: `... check <dir> executing closing --json` → fail = BLOCK. Implementation complete, verification complete/nearly complete. Include `DP-7: 归档确认`.
+Only while the current state is `executing`: implementation is complete and verification is ready. Run the guard `... check <dir> executing closing --json` → fail = BLOCK. `release-archivist` completes verification, audit, and any required delta merge before the final transition. Include `DP-7: 归档确认`.
 
 ### Route to spec-merger
-Delta specs exist that need merging, change closing with ADDED/MODIFIED/REMOVED/RENAMED specs.
+Only while the current state is `executing`, before the final `executing → closing` transition: delta specs need merging with ADDED/MODIFIED/REMOVED/RENAMED specs. Never route a change already in `closing` to `spec-merger`.
 
 ### Route to abandoned
 User explicitly requests, bug-investigator escalates after 3+ failures AND user chooses, scope change makes change no longer worthwhile AND user confirms. Block from `closing` or `abandoned`.
@@ -118,6 +132,7 @@ Use content inspection, not timestamps.
 - No implementation past bug without investigation
 - No closure without all planned wave review receipts recorded as `pass`
 - No closure with unsynced delta specs
+- `closing` is a successful terminal state: next skill is none and recovery overlays do not run
 - No transitions from `abandoned` (terminal)
 - No transition to `abandoned` from `closing` or `abandoned`
 - No auto-abandon without user confirmation

--- a/specs/workflow-routing/spec.md
+++ b/specs/workflow-routing/spec.md
@@ -1,0 +1,55 @@
+# 工作流路由能力规格
+
+## MODIFIED Requirements
+
+### Requirement: closing 是成功完成后的终态
+
+系统检测到 change 的当前状态为 `closing` 时 SHALL 将其视为成功完成后的终态，并且不得再次启动任何收尾流程。
+
+#### Scenario: workflow-start 恢复已关闭的 change
+
+- **WHEN** `workflow-start` 读取到 `.spec-superflow.yaml` 中的 `state` 为 `closing`
+- **THEN** 系统报告当前状态为 `closing`，说明该 change 已经成功关闭，并明确下一步不需要运行任何 skill
+
+#### Scenario: 终态短路后不再执行活跃流程扫描
+
+- **WHEN** `workflow-start` 已确定当前状态为 `closing`
+- **THEN** 系统 MUST 跳过 handoff、checkpoint 和 execution-control 恢复扫描，并且不得路由到 `release-archivist`、`spec-merger`、`build-executor` 或其他工作流 skill
+
+### Requirement: release-archivist 在进入 closing 前完成收尾
+
+系统 SHALL 仅在 change 尚处于 `executing` 且实现与 review 已完成时路由到 `release-archivist`，由它完成进入终态所需的验证和归档门禁。
+
+#### Scenario: executing change 开始收尾
+
+- **WHEN** change 处于 `executing`，所有计划 wave 已实现并通过 review，且用户要求完成收尾
+- **THEN** 系统路由到 `release-archivist`，执行新鲜验证、契约完整性检查、决策审计、风险总结和 DP-7 归档确认
+
+#### Scenario: delta spec 在终态转换前完成同步
+
+- **WHEN** `release-archivist` 发现 change 包含尚未同步的 delta spec
+- **THEN** 系统 MUST 在执行 `executing → closing` 转换之前路由到 `spec-merger` 并记录同步完成
+
+#### Scenario: 收尾门禁全部通过
+
+- **WHEN** 验证、review receipt、delta spec 同步、决策审计和归档确认全部完成
+- **THEN** `release-archivist` 执行 `executing → closing` 转换，并且转换成功后不再保持活跃
+
+### Requirement: 所有工作流表面使用一致的终态语义
+
+规范 skill、正式状态机文档和生成的 phase guard MUST 对 `closing` 使用一致的终态语义，同时保留现有八状态文件格式。
+
+#### Scenario: 生成 closing phase guard
+
+- **WHEN** `ssf inject` 为 `state: closing` 的 change 生成 phase guard
+- **THEN** phase guard 将该状态标识为已成功关闭的终态，禁止实现、验证、归档、spec 合并和状态转换，并且不再提示 DP-6 或 DP-7
+
+#### Scenario: 读取既有 closing 状态文件
+
+- **WHEN** 升级后的系统读取升级前已经包含 `state: closing` 的状态文件
+- **THEN** 系统继续使用现有八状态格式，将该 change 报告为 `CLOSED`，且无需迁移状态文件
+
+#### Scenario: 拒绝 closing 的所有出边转换
+
+- **WHEN** CLI guard 或 state transition 收到任意以 `closing` 为起点的目标状态
+- **THEN** 系统 MUST 拒绝该转换，包括历史遗留的 `closing → specifying`，并且不得修改状态文件

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -85,4 +85,48 @@ describe('closing terminal lifecycle', () => {
     assert.match(closing, /successful terminal/i);
     assert.doesNotMatch(closing, /release-archivist.*active/i);
   });
+
+  it('documents pre-closing work before the terminal closing state', () => {
+    const chineseReadme = read('README.md');
+    const englishReadme = read('docs/README_en.md');
+    const chineseWorkflow = section(chineseReadme, '## 工作流');
+    const englishWorkflow = section(englishReadme, '## Workflow');
+
+    assert.match(chineseReadme,
+      /\| 8 \| `release-archivist` \| 执行内收尾 \|/);
+    assert.doesNotMatch(chineseReadme,
+      /\| 8 \| `release-archivist` \| 收口 \|/);
+    assert.match(englishReadme,
+      /\| 8 \| `release-archivist` \| Pre-closing within executing \|/);
+    assert.doesNotMatch(englishReadme,
+      /\| 8 \| `release-archivist` \| Closing \|/);
+
+    for (const [name, workflow, archivist, merger, archive] of [
+      ['Chinese README', chineseWorkflow, 'release-archivist 验证', 'spec-merger 同步', '归档确认'],
+      ['English README', englishWorkflow, 'release-archivist verifies', 'spec-merger sync', 'archive confirmation'],
+    ]) {
+      const archivistIndex = workflow.indexOf(archivist);
+      const mergerIndex = workflow.indexOf(merger);
+      const archiveIndex = workflow.indexOf(archive);
+      const closingIndex = workflow.indexOf('\n   closing');
+
+      assert.ok(archivistIndex !== -1 && archivistIndex < mergerIndex,
+        `${name} must describe release-archivist verification before spec sync`);
+      assert.ok(mergerIndex < archiveIndex && archiveIndex < closingIndex,
+        `${name} must describe spec sync and archive confirmation before closing`);
+      assert.doesNotMatch(workflow, /^\s*closing\s+.*release-archivist/im,
+        `${name} must not place release-archivist in closing`);
+      assert.match(workflow, /closing.*(?:CLOSED|terminal|终态)/i,
+        `${name} must describe closing as terminal`);
+    }
+  });
+
+  it('records the #64 terminal closing repair in the unreleased changelog', () => {
+    const changelog = read('CHANGELOG.md');
+    const unreleased = section(changelog, '## [Unreleased]');
+
+    assert.match(unreleased, /#64/);
+    assert.match(unreleased, /closing/i);
+    assert.match(unreleased, /终态/);
+  });
 });

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -100,6 +100,18 @@ describe('closing terminal lifecycle', () => {
       /\| 8 \| `release-archivist` \| Pre-closing within executing \|/);
     assert.doesNotMatch(englishReadme,
       /\| 8 \| `release-archivist` \| Closing \|/);
+    assert.match(chineseReadme,
+      /\| 9 \| `spec-merger` \| 执行内收尾 \|/);
+    assert.doesNotMatch(chineseReadme,
+      /\| 9 \| `spec-merger` \| 同步 \|/);
+    assert.match(englishReadme,
+      /\| 9 \| `spec-merger` \| Pre-closing within executing \|/);
+    assert.doesNotMatch(englishReadme,
+      /\| 9 \| `spec-merger` \| Syncing \|/);
+    assert.match(chineseWorkflow,
+      /^\s*pre-closing（仍属于 executing 的收尾步骤，不是新增状态）$/m);
+    assert.match(englishWorkflow,
+      /^\s*pre-closing \(a wrap-up step within executing, not a ninth state\)$/m);
 
     for (const [name, workflow, archivist, merger, archive] of [
       ['Chinese README', chineseWorkflow, 'release-archivist 验证', 'spec-merger 同步', '归档确认'],

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -21,10 +21,19 @@ describe('closing terminal lifecycle', () => {
   it('short-circuits closing before recovery overlays and returns no next skill', () => {
     const workflow = read('skills/workflow-start/SKILL.md');
     const terminal = section(workflow, '## Terminal-State Short Circuit');
+    const updateCheck = workflow.indexOf('1. **Update check**');
     const recovery = workflow.indexOf('## Overlay Recovery Scan');
+    const executionControl = workflow.indexOf('## Execution-Control Recovery Scan');
 
-    assert.ok(workflow.indexOf('## Terminal-State Short Circuit') < recovery,
-      'terminal short circuit must run before overlay recovery scans');
+    for (const [marker, index] of [
+      ['update check', updateCheck],
+      ['overlay recovery', recovery],
+      ['execution-control recovery', executionControl],
+    ]) {
+      assert.notEqual(index, -1, `workflow must include ${marker}`);
+      assert.ok(workflow.indexOf('## Terminal-State Short Circuit') < index,
+        `terminal short circuit must run before ${marker}`);
+    }
     assert.match(terminal, /closing.*terminal/i);
     assert.match(terminal, /next skill.*none/i);
     assert.match(terminal,
@@ -78,12 +87,61 @@ describe('closing terminal lifecycle', () => {
     }
   });
 
+  it('places the release guard before every closing side effect and makes transition last', () => {
+    const archivist = read('skills/release-archivist/SKILL.md');
+    const guard = archivist.indexOf('## Execution-State Guard');
+    const audit = archivist.indexOf('npx --yes --package spec-superflow@0.10.0 ssf audit <change-dir>');
+    const dp6 = archivist.indexOf('### DP-6 (Verification Outcome)');
+    const dp7 = archivist.indexOf('### DP-7 (Archive Confirmation)');
+    const merger = archivist.indexOf('invoke `spec-merger`');
+    const transition = archivist.indexOf('npx --yes --package spec-superflow@0.10.0 ssf state transition <change-dir> closing');
+
+    for (const [marker, index] of [
+      ['release guard', guard],
+      ['audit command', audit],
+      ['DP-6', dp6],
+      ['DP-7', dp7],
+      ['spec-merger', merger],
+      ['final transition', transition],
+    ]) {
+      assert.notEqual(index, -1, `release-archivist must include ${marker}`);
+    }
+
+    for (const [marker, index] of [
+      ['audit command', audit],
+      ['DP-6', dp6],
+      ['DP-7', dp7],
+      ['spec-merger', merger],
+      ['final transition', transition],
+    ]) {
+      assert.ok(guard < index, `release guard must run before ${marker}`);
+      assert.ok(index <= transition, `${marker} must occur no later than the final transition`);
+    }
+    assert.equal(
+      (archivist.match(/npx --yes --package spec-superflow@0\.10\.0 ssf state transition <change-dir> closing/g) || []).length,
+      1,
+      'the actual final transition command must occur exactly once'
+    );
+  });
+
   it('defines closing as a successful terminal state with no active archivist', () => {
     const stateMachine = read('docs/state-machine.md');
     const closing = section(stateMachine, '### `closing`');
 
     assert.match(closing, /successful terminal/i);
     assert.doesNotMatch(closing, /release-archivist.*active/i);
+  });
+
+  it('draws scope-change rewind only from non-terminal states and starts a new change after closing', () => {
+    const stateMachine = read('docs/state-machine.md');
+    const transitions = section(stateMachine, '## Transitions');
+
+    assert.doesNotMatch(transitions, /closing\s*(?:→|->|─+>)\s*specifying/i,
+      'formal diagram must not draw a closing → specifying arrow');
+    assert.match(transitions, /scope change.*non-terminal.*re-specify/is,
+      'formal diagram must limit scope-change rewind to non-terminal states');
+    assert.match(transitions, /closing.*scope change.*new change/is,
+      'formal diagram must direct post-closing scope changes to a new change');
   });
 
   it('documents pre-closing work before the terminal closing state', () => {

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -107,16 +107,11 @@ describe('closing terminal lifecycle', () => {
       assert.notEqual(index, -1, `release-archivist must include ${marker}`);
     }
 
-    for (const [marker, index] of [
-      ['audit command', audit],
-      ['DP-6', dp6],
-      ['DP-7', dp7],
-      ['spec-merger', merger],
-      ['final transition', transition],
-    ]) {
-      assert.ok(guard < index, `release guard must run before ${marker}`);
-      assert.ok(index <= transition, `${marker} must occur no later than the final transition`);
-    }
+    assert.ok(guard < audit, 'release guard must run before the actual audit command');
+    assert.ok(audit < dp6, 'actual audit command must run before DP-6');
+    assert.ok(dp6 < dp7, 'DP-6 must be recorded before DP-7');
+    assert.ok(dp7 < merger, 'DP-7 must be recorded before invoking spec-merger');
+    assert.ok(merger < transition, 'spec-merger must run before the actual final transition');
     assert.equal(
       (archivist.match(/npx --yes --package spec-superflow@0\.10\.0 ssf state transition <change-dir> closing/g) || []).length,
       1,

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -42,6 +42,42 @@ describe('closing terminal lifecycle', () => {
     assert.match(merger, /closing.*must not.*route.*spec-merger/is);
   });
 
+  it('stops pre-closing skills on a persisted non-executing state before side effects', () => {
+    const archivist = read('skills/release-archivist/SKILL.md');
+    const merger = read('skills/spec-merger/SKILL.md');
+    const archivistGuard = section(archivist, '## Execution-State Guard');
+    const mergerGuard = section(merger, '## Execution-State Guard');
+
+    for (const [name, guard] of [
+      ['release-archivist', archivistGuard],
+      ['spec-merger', mergerGuard],
+    ]) {
+      assert.match(guard, /ssf state get <change-dir> state/,
+        `${name} must inspect the persisted state`);
+      assert.match(guard, /exactly.*`executing`/i,
+        `${name} must allow only executing`);
+      assert.match(guard, /closing.*STOP/is,
+        `${name} must stop for the terminal closing state`);
+      assert.match(guard, /any other.*state.*STOP/is,
+        `${name} must stop for every other non-executing state`);
+    }
+
+    assert.ok(merger.indexOf('## Execution-State Guard') < merger.indexOf('ssf sync'),
+      'spec-merger must guard before sync can write main specs');
+    for (const sideEffect of [
+      '### Step 1: Test Suite',
+      'ssf audit',
+      'ssf state set <change-dir> dp_6_result',
+      'ssf state set <change-dir> dp_7_result',
+      'invoke `spec-merger`',
+    ]) {
+      assert.notEqual(archivist.indexOf(sideEffect), -1,
+        `release-archivist fixture must include ${sideEffect}`);
+      assert.ok(archivist.indexOf('## Execution-State Guard') < archivist.indexOf(sideEffect),
+        `release-archivist must guard before ${sideEffect}`);
+    }
+  });
+
   it('defines closing as a successful terminal state with no active archivist', () => {
     const stateMachine = read('docs/state-machine.md');
     const closing = section(stateMachine, '### `closing`');

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -1,0 +1,52 @@
+// Contract tests for #64: closing is a successful terminal state.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+
+function read(relativePath) {
+  return readFileSync(join(ROOT, relativePath), 'utf8');
+}
+
+function section(content, heading) {
+  const start = content.indexOf(heading);
+  assert.notEqual(start, -1, `missing section: ${heading}`);
+  const next = content.indexOf('\n## ', start + heading.length);
+  return content.slice(start, next === -1 ? undefined : next);
+}
+
+describe('closing terminal lifecycle', () => {
+  it('short-circuits closing before recovery overlays and returns no next skill', () => {
+    const workflow = read('skills/workflow-start/SKILL.md');
+    const terminal = section(workflow, '## Terminal-State Short Circuit');
+    const recovery = workflow.indexOf('## Overlay Recovery Scan');
+
+    assert.ok(workflow.indexOf('## Terminal-State Short Circuit') < recovery,
+      'terminal short circuit must run before overlay recovery scans');
+    assert.match(terminal, /closing.*terminal/i);
+    assert.match(terminal, /next skill.*none/i);
+    assert.match(terminal,
+      /do not run.*handoff.*checkpoint.*execution-control.*release-archivist/is);
+  });
+
+  it('performs archival verification and delta merging while executing before its final transition', () => {
+    const archivist = read('skills/release-archivist/SKILL.md');
+    const merger = read('skills/spec-merger/SKILL.md');
+
+    assert.match(archivist, /state.*executing/i);
+    assert.match(archivist, /spec-merger.*before.*executing\s*→\s*closing/is);
+    assert.match(archivist, /executing\s*→\s*closing.*final/i);
+    assert.match(merger, /executing\s*→\s*closing/i);
+    assert.match(merger, /closing.*must not.*route.*spec-merger/is);
+  });
+
+  it('defines closing as a successful terminal state with no active archivist', () => {
+    const stateMachine = read('docs/state-machine.md');
+    const closing = section(stateMachine, '### `closing`');
+
+    assert.match(closing, /successful terminal/i);
+    assert.doesNotMatch(closing, /release-archivist.*active/i);
+  });
+});

--- a/tests/lib/cmd-inject.test.mjs
+++ b/tests/lib/cmd-inject.test.mjs
@@ -72,10 +72,15 @@ describe('cmd-inject: generatePhaseGuard()', () => {
     assert.ok(result.includes('TDD 修复循环'));
   });
 
-  it('generates closing phase with verification', () => {
+  it('generates closing phase as a successful terminal state', () => {
     const result = generatePhaseGuard({ state: 'closing', change_name: 'test' });
-    assert.ok(result.includes('三维验证'));
-    assert.ok(result.includes('DP-7'));
+    assert.ok(result.includes('已成功关闭'));
+    assert.ok(result.includes('终止状态'));
+    assert.ok(result.includes('不允许任何进一步操作'));
+    assert.ok(!result.includes('三维验证'));
+    assert.ok(!result.includes('DP-6'));
+    assert.ok(!result.includes('DP-7'));
+    assert.ok(!result.includes('合并 delta specs'));
   });
 
   it('generates abandoned terminal state', () => {

--- a/tests/lib/guard-transitions.test.mjs
+++ b/tests/lib/guard-transitions.test.mjs
@@ -202,16 +202,20 @@ describe('Terminal state protection — abandoned', () => {
   }
 });
 
-// Scenario: 从 closing 不能进入 abandoned
+// Scenario: closing 后拒绝所有 transition
 describe('Terminal state protection — closing', () => {
   let dir;
   before(() => { dir = makeChangeDir(); });
   after(() => { cleanup(dir); });
 
-  it('SHALL reject closing → abandoned', () => {
-    const result = runGuard('closing', 'abandoned', dir);
-    assert.equal(result.ok, false, 'Closing → abandoned must be rejected (both terminal)');
-  });
+  const allTargets = ['exploring', 'specifying', 'bridging', 'approved-for-build', 'executing', 'debugging', 'abandoned'];
+
+  for (const target of allTargets) {
+    it(`SHALL reject closing → ${target}`, () => {
+      const result = runGuard('closing', target, dir);
+      assert.equal(result.ok, false, `Closing → ${target} must be rejected (closing is terminal)`);
+    });
+  }
 });
 
 // ─── D1: Fast-path validation ───

--- a/tests/lib/guard-transitions.test.mjs
+++ b/tests/lib/guard-transitions.test.mjs
@@ -4,7 +4,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -80,15 +80,25 @@ function runGuard(from, to, dir, workflow = 'full') {
     writeFileSync(join(dir, 'specs', 'test', 'spec.md'), '## ADDED Requirements\n\n### Requirement: Test\n\nThe system SHALL test.\n\n#### Scenario: Test\n- **WHEN** test\n- **THEN** test\n');
     writeFileSync(join(dir, 'execution-contract.md'), '# Execution Contract\n\n## Intent Lock\n\nTest.\n');
 
-    const cmd = `node ${GUARD} check "${dir}" ${from} ${to}`;
+    const args = [GUARD, 'check', dir, from, to, '--json'];
     if (workflow !== 'full') {
-      execSync(`${cmd} --workflow ${workflow} --json`, { stdio: 'pipe', timeout: 5000 });
-    } else {
-      execSync(`${cmd} --json`, { stdio: 'pipe', timeout: 5000 });
+      args.push('--workflow', workflow);
     }
-    return { ok: true };
+
+    const stdout = execFileSync(process.execPath, args, { encoding: 'utf8', timeout: 5000 });
+    return { ok: true, status: 0, stdout, stderr: '', signal: null, timedOut: false, spawnError: null };
   } catch (e) {
-    return { ok: false, stdout: e.stdout?.toString() || '', stderr: e.stderr?.toString() || e.message };
+    const errorCode = typeof e.code === 'string' ? e.code : null;
+    const timedOut = errorCode === 'ETIMEDOUT' || (e.killed === true && e.status === null);
+    return {
+      ok: false,
+      status: e.status ?? null,
+      stdout: e.stdout?.toString() || '',
+      stderr: e.stderr?.toString() || '',
+      signal: e.signal ?? null,
+      timedOut,
+      spawnError: timedOut ? null : errorCode,
+    };
   }
 }
 
@@ -213,7 +223,21 @@ describe('Terminal state protection — closing', () => {
   for (const target of allTargets) {
     it(`SHALL reject closing → ${target}`, () => {
       const result = runGuard('closing', target, dir);
-      assert.equal(result.ok, false, `Closing → ${target} must be rejected (closing is terminal)`);
+      const expectedError = `Unknown transition: closing -> ${target}`;
+
+      assert.equal(result.timedOut, false, `Closing → ${target} must not time out`);
+      assert.equal(result.spawnError, null, `Closing → ${target} must not fail to spawn the guard`);
+      assert.equal(result.signal, null, `Closing → ${target} must not terminate by signal`);
+      assert.equal(result.status, 1, `Closing → ${target} must exit with the guard rejection status`);
+      assert.equal(result.stderr, '', `Closing → ${target} must report its rejection as JSON stdout`);
+
+      let response;
+      assert.doesNotThrow(() => { response = JSON.parse(result.stdout); },
+        `Closing → ${target} must return parseable JSON: ${result.stdout}`);
+      assert.equal(response.pass, false, `Closing → ${target} response must fail`);
+      assert.deepEqual(response.checks, [], `Closing → ${target} must not run transition checks`);
+      assert.match(response.error, new RegExp(`^${expectedError.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}`),
+        `Closing → ${target} must report the authoritative unknown-transition error`);
     });
   }
 });


### PR DESCRIPTION
## 变更说明

修复 #64，使 `closing` 在所有工作流表面和权威运行时中都成为真正的成功终态。

- `workflow-start` 在 update、handoff/checkpoint overlay 与 execution-control 扫描前短路 `closing`，返回 `CLOSED` / `next skill: none`
- `release-archivist` 与 `spec-merger` 仅允许在 `executing` 中运行，并在任何 audit、DP 写入或 spec sync 副作用前校验持久化状态
- 删除遗留的 `closing → specifying` guard 出边，七个 closing 出边现在都返回结构化非法转换结果
- closing phase guard 不再提示三维验证、DP-6、DP-7 或重复 delta spec 合并
- 同步中英文 README、状态机、Changelog 和主 `workflow-routing` 规格
- 增加顺序敏感、进程错误敏感的回归测试

## 根因

`ssf list` 已将 `closing` 映射为 `CLOSED`，但 canonical skills、phase guard 和状态机文档仍把 closing 当成活跃收口阶段；同时运行时矩阵保留了 `closing:specifying`，导致“终态”只存在于部分表面。

## 验证

- `npm run build`：通过
- `node --test tests/lib/guard-transitions.test.mjs tests/lib/closing-terminal-semantics.test.mjs`：60/60 通过
- `node --test tests/lib/cmd-inject.test.mjs`：21/21 通过
- `npm run validate -- changes/fix-closing-terminal-routing`：0 errors / warnings
- `node scripts/lint/lint-skills.mjs`：0 errors
- `git diff --check`：通过
- 最终独立整分支审查：PASS — Ready to merge

本机 Node 24 完整测试为 435 项、429 通过、6 失败；失败仅来自两个既有测试 helper 的固定 `timeout: 5000`（`guard-specs-merged`、`guard-tests-passing`），未修改相关文件，且同路径后续用例通过。仓库 CI 将继续在 Node 20/22 验证。

Closes #64
