### PR TITLE
fix: inherit planning artifact language

### DIFF
--- a/skills/contract-builder/SKILL.md
+++ b/skills/contract-builder/SKILL.md
@@ -7,7 +7,19 @@ description: Convert approved planning artifacts into an execution contract. Inv
 
 Converts planning artifacts into a single execution handshake: `execution-contract.md`. Load the baseline with `npx --yes --package spec-superflow@0.10.0 ssf runtime asset read templates/execution-contract.md`.
 
-Read before generating: `proposal.md`, `specs/`, `design.md`, `tasks.md`, then load `docs/artifact-contract.md` with `npx --yes --package spec-superflow@0.10.0 ssf runtime asset read docs/artifact-contract.md`.
+Read before generating: `.spec-superflow.yaml` (especially `dp_0_decisions`),
+`proposal.md`, `specs/`, `design.md`, `tasks.md`, then load
+`docs/artifact-contract.md` with `npx --yes --package spec-superflow@0.10.0 ssf runtime asset read docs/artifact-contract.md`.
+
+## Artifact Language
+
+Read `artifact_language=<concrete-language>` from `dp_0_decisions`. Generate
+`execution-contract.md` in the same language as that resolved value and the
+approved planning artifacts. Preserve required schema keywords and code
+identifiers verbatim; language consistency applies to explanatory prose and
+headings. If the concrete artifact language is missing or still `auto`, route
+back to `workflow-start` before writing the contract instead of guessing or
+silently defaulting to English.
 
 ## Artifact Mapping
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -44,6 +44,25 @@ Run DP-0 when: change folder doesn't exist, planning artifacts missing/empty, or
 
 Ask: change name + one-sentence intent, known constraints, related optimizations (include or stay focused?), communication preference (ask per decision or draft for review).
 
+### Artifact Language Resolution
+
+Before the first planning artifact is generated, resolve one concrete artifact
+language in this priority order:
+
+1. explicit user language
+2. the conversation's primary language
+3. an explicit non-`auto` `execution.defaultLanguage`
+4. the primary language of existing planning artifacts in the current change
+5. the primary language of the project templates
+
+Treat `execution.defaultLanguage: auto` as a request to continue resolving, not
+as a language. Append `artifact_language=<concrete-language>` to
+`dp_0_decisions`, preserving its existing scope and constraint summary. Never
+persist `auto` as the resolved artifact language. If DP-0 was already confirmed
+but this field is absent, resolve and append it before routing to `spec-writer`.
+All later planning skills reuse this field so one change does not switch
+languages without an explicit user request.
+
 After confirmation:
 ```bash
 npx --yes --package spec-superflow@0.10.0 ssf state set <change-dir> dp_0_decisions "<summary>"
@@ -52,7 +71,8 @@ npx --yes --package spec-superflow@0.10.0 ssf state set <change-dir> dp_0_confir
 npx --yes --package spec-superflow@0.10.0 ssf state set <change-dir> dp_0_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 
-Config-aware routing: check `artifacts.order` and `artifacts.skip` from project config.
+Config-aware routing: check `artifacts.order`, `artifacts.skip`, and
+`execution.defaultLanguage` from project config.
 
 ## Mode Detection
 


### PR DESCRIPTION
## Summary

- resolve one concrete planning-artifact language at DP-0
- prioritize an explicit user choice, then the conversation language, explicit configuration, existing artifacts, and templates
- persist the resolved language in `dp_0_decisions` and never persist `auto`
- require `contract-builder` to inherit that language or route back for resolution

## Root cause

The workflow treated `execution.defaultLanguage: auto` as configuration context but did not resolve it into a concrete artifact language before planning began. Later skills therefore had no durable language decision to inherit and could silently fall back to English.

## User impact

Chinese and other non-English conversations now keep proposal, specification, design, task, and execution-contract prose in the resolved conversation language unless the user explicitly chooses another language.

## Scope

- `skills/workflow-start/SKILL.md`
- `skills/contract-builder/SKILL.md`

No new state, configuration key, runtime module, API, or schema is introduced.

## Verification

- `npm run build` — passed
- Node 20 full suite — 489/489 passed
- language-resolution and inheritance behavior assertions — 2/2 passed
- `git diff --check origin/main...HEAD` — passed
- independent review — PASS, no findings
- real hotfix closure — `executing -> closing` passed

Closes #65
