### PR TITLE
fix: enumerate CodeBuddy marketplace skills

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -22,5 +22,15 @@
     "copilot"
   ],
   "category": "Productivity",
-  "skills": "skills/"
+  "skills": [
+    "./skills/bug-investigator",
+    "./skills/build-executor",
+    "./skills/code-reviewer",
+    "./skills/contract-builder",
+    "./skills/need-explorer",
+    "./skills/release-archivist",
+    "./skills/spec-merger",
+    "./skills/spec-writer",
+    "./skills/workflow-start"
+  ]
 }

--- a/tests/lib/codebuddy-manifest.test.mjs
+++ b/tests/lib/codebuddy-manifest.test.mjs
@@ -1,0 +1,30 @@
+// tests/lib/codebuddy-manifest.test.mjs
+// Root marketplace manifests must enumerate skills for CodeBuddy discovery.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const EXPECTED_SKILLS = [
+  'bug-investigator',
+  'build-executor',
+  'code-reviewer',
+  'contract-builder',
+  'need-explorer',
+  'release-archivist',
+  'spec-merger',
+  'spec-writer',
+  'workflow-start',
+];
+
+describe('CodeBuddy marketplace manifest', () => {
+  it('enumerates every skill as a discoverable plugin path', () => {
+    const manifest = JSON.parse(readFileSync(join(ROOT, 'plugin.json'), 'utf8'));
+
+    assert.deepEqual(manifest.skills, EXPECTED_SKILLS.map(name => `./skills/${name}`));
+    for (const skillPath of manifest.skills) {
+      assert.ok(existsSync(join(ROOT, skillPath, 'SKILL.md')), `${skillPath} must contain SKILL.md`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #77

## Summary

- Enumerate all nine skills in the root `plugin.json` manifest.
- Add a regression test that verifies each declared path contains `SKILL.md`.

## Root cause

The root manifest declared `skills` as the single directory string `"skills/"`. CodeBuddy marketplace indexing does not recursively expand that entry, so its cache exposed only the directory rather than callable skills.

## Impact

CodeBuddy can now discover each workflow skill explicitly after refreshing or reinstalling the marketplace plugin. Existing command assets and other platform manifests are unchanged.

## Validation

- `npm test`
- `npm run check-versions`
- `git diff --check`
