### PR TITLE
fix: resolve relative paths in state guard

### DIFF
--- a/scripts/lib/cmd-state.mjs
+++ b/scripts/lib/cmd-state.mjs
@@ -2,7 +2,7 @@
 import { parseArgs } from 'node:util';
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readState, writeState, updateField, rebuildState } from './state-loader.mjs';
 import { computeArtifactsHash, computeContractHash } from './hash.mjs';
@@ -124,10 +124,14 @@ export async function run(args) {
 
       // Run guard before allowing transition (H-2: enforce guard)
       const guardScript = join(__dirname, '..', 'guard', 'guard.mjs');
+      // The guard runs from the bundled plugin directory. Resolve a relative
+      // change path from the caller project before spawning it so both commands
+      // inspect the same artifacts.
+      const guardChangeDir = resolve(changeDir);
       const rawWorkflow = state.workflow || 'full';
       // Normalize: guard only accepts full/hotfix/tweak, not "auto"
       const workflow = rawWorkflow === 'auto' ? 'full' : rawWorkflow;
-      const guardResult = spawnSync('node', [guardScript, 'check', changeDir, fromState, toState, '--json', '--workflow', workflow], {
+      const guardResult = spawnSync('node', [guardScript, 'check', guardChangeDir, fromState, toState, '--json', '--workflow', workflow], {
         cwd: join(__dirname, '..', '..'),
         timeout: 10_000,
       });

--- a/tests/lib/cmd-state.test.mjs
+++ b/tests/lib/cmd-state.test.mjs
@@ -139,6 +139,26 @@ describe('cmd-state: transition', () => {
     assert.equal(parsed.state, 'specifying');
   });
 
+  it('uses the caller project directory for a relative change path', () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'ssf-state-relative-project-'));
+    const changeDir = join(projectRoot, 'changes', 'relative-change');
+    try {
+      mkdirSync(join(changeDir, 'specs', 'test'), { recursive: true });
+      writeFileSync(join(changeDir, 'proposal.md'), '## Why\nA relative path transition must inspect artifacts in the caller project, not the plugin directory.\n## What Changes\n- Add a transition fixture.');
+      writeFileSync(join(changeDir, 'design.md'), '# Design\n## Context\nTest.\n## Goals\nTest.\n## Decisions\n### D1\n- Choice: Test\n- Rationale: Test\n\n## Risks And Trade-Offs\nNone.');
+      writeFileSync(join(changeDir, 'tasks.md'), '# Tasks\n- [x] Task 1');
+      writeFileSync(join(changeDir, 'specs', 'test', 'spec.md'), '## ADDED Requirements\n### Requirement: Relative transition\nThe system SHALL resolve relative change paths from the caller project.\n#### Scenario: Transition\n- **WHEN** a project invokes state transition with a relative path\n- **THEN** its artifacts are checked.');
+
+      assert.equal(ssf('state init changes/relative-change', { cwd: projectRoot }).exitCode, 0);
+      const result = ssf('state transition changes/relative-change specifying', { cwd: projectRoot });
+
+      assert.equal(result.exitCode, 0, result.stderr);
+      assert.match(result.stdout, /exploring -> specifying/);
+    } finally {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects exploring to approved-for-build when workflow is auto', () => {
     rmSync(join(tempDir, '.spec-superflow.yaml'), { force: true });
     ssf(`state init ${tempDir}`);


### PR DESCRIPTION
Closes #76

## Summary

- Resolve relative change paths before `ssf state transition` spawns the bundled guard.
- Add a regression test that runs the CLI from a separate project directory.

## Root cause

The transition command ran the guard with the plugin directory as its working directory, while forwarding a caller-relative `changes/<name>` path unchanged. The guard consequently inspected the plugin directory instead of the caller project and reported required artifacts as missing.

## Impact

CodeBuddy, and every other installation surface, can resume and advance a workflow when the project uses a relative change path. Direct guard checks and state transitions now inspect the same artifacts.

## Validation

- `node --test tests/lib/cmd-state.test.mjs --test-name-pattern="relative change path"`
- `npm test`
- `npm run check-versions`
- `git diff --check`
