### PR TITLE
feat: add user-controlled lightweight workflow paths

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -815,4 +815,4 @@ Checkpoint 是任务级恢复上下文。`result-ready` handoff 在继续受影�
 
 Full/legacy 推荐流程：`exploring -> specifying -> bridging -> approved-for-build -> execution plan -> executing -> closing`
 
-Quick（≤3 低风险文件/任务）与 direct Hotfix（incident，≤2）走 `exploring -> approved-for-build -> executing`，同轮推荐/接受后直接验证；direct Hotfix 必须复现原症状回归。legacy Hotfix 才走最小契约、DP-3、plan/review 路径。
+Quick（≤3 单模块代码文件/任务）与 direct Hotfix（incident，≤2）走 `exploring -> approved-for-build -> executing`。Quick 低风险时同轮推荐/接受；若涉及 PRD、Spec/Design、API、数据/权限或跨模块，必须展示风险并由用户选择 Quick 或 Full。选择 Quick 时记录 `tdd`、`new-test` 或 `bounded` 验证策略；direct Hotfix 必须复现原症状回归。legacy Hotfix 才走最小契约、DP-3、plan/review 路径。

--- a/README.md
+++ b/README.md
@@ -329,11 +329,11 @@ overlay，不会增加第九个状态；其 CLI 与 CodeBuddy/WorkBuddy Markdown
    closing            CLOSED 成功终态（无 next skill）
 ```
 
-**关键约束：** Full/legacy Hotfix 没有 `execution-contract.md`、current execution plan 或 `pass` review receipt → 不允许推进；Quick/direct Hotfix/Tweak 以有效 receipt、边界检查与 `test_result: pass` 放行。任何风险升级转 Full。
+**关键约束：** Full/legacy Hotfix 没有 `execution-contract.md`、current execution plan 或 `pass` review receipt → 不允许推进；Quick/direct Hotfix/Tweak 以有效 receipt、边界检查与 `test_result: pass` 放行。风险只触发建议与用户选择，绝不自动升级到 Full。
 
 ### 快速路径（Quick / Hotfix / Tweak）
 
-- **Quick** — ≤3 文件/任务、低风险代码：同轮推荐/接受，`exploring -> approved-for-build -> executing`，跑定向验证。
+- **Quick** — ≤3 文件/任务、单模块代码：低风险时同轮推荐/接受；触及 PRD、Spec/Design、API、数据/权限或跨模块时，展示风险后由用户选择 Quick 或 Full。选择 Quick 会记录 `tdd`、`new-test` 或 `bounded` 验证策略。
 - **direct Hotfix** — incident 且≤2 文件/任务：同一路径，必须验证原症状回归。
 - **legacy Hotfix** — 既有或无 direct receipt：保留最小契约、DP-3、plan/review。
 - **tweak** — ≤4 文件、纯配置/文档修改时，跳过规划+桥接，直接编辑

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -301,7 +301,7 @@ same guards.
 
 ### Fast Paths (Quick / Hotfix / Tweak)
 
-- **Quick** — ≤3 low-risk code files/tasks → same-turn recommendation and direct acceptance, then targeted verification.
+- **Quick** — ≤3 single-module code files/tasks → direct acceptance when low risk; for PRD, Spec/Design, API, data/permission, or cross-module impact, show the risk and let the user choose Quick or Full. A chosen Quick records `tdd`, `new-test`, or `bounded` verification.
 - **direct Hotfix** — incident, ≤2 files/tasks → direct path plus original-symptom regression.
 - **legacy Hotfix** — no direct receipt → minimal contract, DP-3, execution plan, and review remain required.
 - **tweak** — ≤4 files, config/docs only → skip planning + bridging, direct edit

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -27,8 +27,9 @@ valid direct receipt needed by its short path. The legacy `runtime infer`
 compatibility API may return `full` for an empty directory, but it never
 replaces the user's intake selection.
 
-Quick is not a selectable workflow: it must use direct acceptance. To escalate
-Quick, direct Hotfix, or Tweak, run `ssf workflow recommend` with the updated
+Low-risk Quick uses direct acceptance. A risk-signalled Quick is selectable only
+with an acknowledgement and an explicit verification strategy. To change a
+Quick, direct Hotfix, or Tweak choice, run `ssf workflow recommend` with the updated
 facts, then confirm `ssf workflow select --mode full`; that replaces the short
 selection with an auditable Full intake receipt.
 

--- a/scripts/lib/cmd-workflow.mjs
+++ b/scripts/lib/cmd-workflow.mjs
@@ -17,6 +17,8 @@ const OPTIONS = {
   'config-doc-only': { type: 'string' },
   'schema-api-change': { type: 'string' },
   'new-module': { type: 'string' },
+  'behavioral-constraint-change': { type: 'string' },
+  'cross-module-change': { type: 'string' },
   uncertainty: { type: 'string' },
   'request-kind': { type: 'string' },
   mode: { type: 'string' },
@@ -24,6 +26,7 @@ const OPTIONS = {
   reason: { type: 'string' },
   'acknowledge-recommendation': { type: 'boolean', default: false },
   source: { type: 'string' },
+  verification: { type: 'string' },
   json: { type: 'boolean', default: false },
   help: { type: 'boolean', default: false },
 };
@@ -32,9 +35,11 @@ const BOOLEAN_FACTS = {
   'config-doc-only': ['yes', 'no', 'unknown'],
   'schema-api-change': ['yes', 'no', 'unknown'],
   'new-module': ['yes', 'no', 'unknown'],
+  'behavioral-constraint-change': ['yes', 'no', 'unknown'],
+  'cross-module-change': ['yes', 'no', 'unknown'],
 };
 
-const SELECTABLE_WORKFLOW_MODES = Object.freeze(['full', 'hotfix', 'tweak']);
+const SELECTABLE_WORKFLOW_MODES = Object.freeze(['full', 'hotfix', 'tweak', 'quick']);
 
 class UsageError extends Error {}
 
@@ -93,6 +98,7 @@ function select(changeDir, state, values) {
     reason: values.reason,
     confirmed: values.confirm,
     acknowledged: values['acknowledge-recommendation'],
+    verificationStrategy: parseVerification(values.verification),
   });
   persistWorkflowSelection(changeDir, state, record);
   return print({ ok: true, source: 'user-confirmed', record }, values.json);
@@ -103,7 +109,10 @@ function canEscalateToFull(state, values) {
 }
 
 function accept(changeDir, state, values) {
-  const record = acceptWorkflowRecommendation(changeDir, { source: values.source });
+  const record = acceptWorkflowRecommendation(changeDir, {
+    source: values.source,
+    verificationStrategy: parseVerification(values.verification) ?? 'bounded',
+  });
   persistWorkflowSelection(changeDir, state, record);
   return print({ ok: true, source: 'direct-request', record }, values.json);
 }
@@ -162,9 +171,21 @@ function factsFrom(values) {
     config_doc_only: parseFact(values['config-doc-only'], 'config-doc-only'),
     schema_api_change: parseFact(values['schema-api-change'], 'schema-api-change'),
     new_module: parseFact(values['new-module'], 'new-module'),
+    behavioral_constraint_change: values['behavioral-constraint-change'] === undefined
+      ? 'no' : parseFact(values['behavioral-constraint-change'], 'behavioral-constraint-change'),
+    cross_module_change: values['cross-module-change'] === undefined
+      ? 'no' : parseFact(values['cross-module-change'], 'cross-module-change'),
     uncertainty: parseFact(values.uncertainty, 'uncertainty'),
     request_kind: parseRequestKind(values['request-kind']),
   };
+}
+
+function parseVerification(value) {
+  if (value === undefined) return null;
+  if (!['tdd', 'new-test', 'bounded'].includes(value)) {
+    throw new UsageError('verification must be one of: tdd, new-test, bounded');
+  }
+  return value;
 }
 
 function parseRequestKind(value) {
@@ -244,6 +265,9 @@ function formatRecordDetails(value, record) {
   if (record?.recommendation) {
     lines.push(`Recommended: ${record.recommendation.mode}`);
     lines.push(`Why: ${record.recommendation.reasons.join(' ')}`);
+    if (record.recommendation.risk_reasons?.length) {
+      lines.push(`Risk: ${record.recommendation.risk_reasons.join('; ')}`);
+    }
   }
   if (record?.missing_facts?.length) {
     lines.push(`Missing facts: ${record.missing_facts.join(', ')}`);
@@ -273,8 +297,8 @@ function fail(message, exitCode) {
 
 function printHelp() {
   console.log(`Usage:
-  ssf workflow recommend <change-dir> [--task-count <n>] [--file-count <n>] [--config-doc-only yes|no|unknown] [--schema-api-change yes|no|unknown] [--new-module yes|no|unknown] [--uncertainty low|high|unknown] [--request-kind standard|incident] [--json]
-  ssf workflow select <change-dir> --mode full|hotfix|tweak --confirm --reason <text> [--acknowledge-recommendation] [--json]
-  ssf workflow accept <change-dir> --source direct-request [--json]
+  ssf workflow recommend <change-dir> [--task-count <n>] [--file-count <n>] [--config-doc-only yes|no|unknown] [--schema-api-change yes|no|unknown] [--new-module yes|no|unknown] [--behavioral-constraint-change yes|no] [--cross-module-change yes|no] [--uncertainty low|high|unknown] [--request-kind standard|incident] [--json]
+  ssf workflow select <change-dir> --mode full|hotfix|tweak|quick --confirm --reason <text> [--acknowledge-recommendation] [--verification tdd|new-test|bounded] [--json]
+  ssf workflow accept <change-dir> --source direct-request [--verification tdd|new-test|bounded] [--json]
   ssf workflow show <change-dir> [--json]`);
 }

--- a/scripts/lib/install.mjs
+++ b/scripts/lib/install.mjs
@@ -137,7 +137,7 @@ function phaseGuardContent(rulesFormat, platformId) {
 - Full 或 legacy Hotfix 没有 execution-contract.md 或未经用户明确批准，不得进入实现。
 - Full 或 legacy Hotfix 必须先运行 ssf execution plan <change-dir> ...；没有 current execution plan 不得开始实现。
 - 只有 Full/legacy Hotfix 的 all pass review receipts 后才可 closing；不得把未审查的 wave 当作完成。
-- Quick、direct Hotfix、tweak 不要求 contract、execution plan、review receipt 或 DP-3/DP-4；它们须在边界内验证并持久化 test_result: pass。direct Hotfix 必须验证原症状回归。
+- Quick、direct Hotfix、tweak 不要求 contract、execution plan、review receipt 或 DP-3/DP-4；它们须在边界内验证并持久化 test_result: pass。Quick 仅限 ≤3 单模块代码文件；出现 PRD、Spec/Design、API、数据/权限或跨模块风险时，展示 Quick/Full 选择，用户选择 Quick 必须在 receipt 中记录 tdd、new-test 或 bounded 验证策略。direct Hotfix 必须验证原症状回归。
 - 执行过程中如果发现需求/范围变化，必须回退到 specifying 或 bridging，而不是直接改代码。
 - 不要直接调用执行类 skill（如 "/build-executor"），必须通过入口路由。
 

--- a/scripts/lib/workflow-recommendation.mjs
+++ b/scripts/lib/workflow-recommendation.mjs
@@ -7,7 +7,7 @@ import { getOverlayPaths } from './sdd-overlay.mjs';
 
 export const WORKFLOW_MODES = Object.freeze(['full', 'hotfix', 'tweak', 'quick']);
 
-const BOOLEAN_FACTS = ['config_doc_only', 'schema_api_change', 'new_module'];
+const BOOLEAN_FACTS = ['config_doc_only', 'schema_api_change', 'new_module', 'behavioral_constraint_change', 'cross_module_change'];
 const FACT_KEYS = ['task_count', 'file_count', ...BOOLEAN_FACTS, 'uncertainty'];
 
 export function normalizeWorkflowFacts(input = {}) {
@@ -17,6 +17,10 @@ export function normalizeWorkflowFacts(input = {}) {
     config_doc_only: normalizeEnum(input.config_doc_only, ['yes', 'no', 'unknown']),
     schema_api_change: normalizeEnum(input.schema_api_change, ['yes', 'no', 'unknown']),
     new_module: normalizeEnum(input.new_module, ['yes', 'no', 'unknown']),
+    // These are intentionally optional for legacy callers. Agents MUST set them when
+    // the request reveals a requirement/spec/design or cross-module impact.
+    behavioral_constraint_change: normalizeEnum(input.behavioral_constraint_change ?? 'no', ['yes', 'no', 'unknown']),
+    cross_module_change: normalizeEnum(input.cross_module_change ?? 'no', ['yes', 'no', 'unknown']),
     uncertainty: normalizeEnum(input.uncertainty, ['low', 'high', 'unknown']),
     request_kind: normalizeRequestKind(input.request_kind),
   };
@@ -36,8 +40,9 @@ export function recommendWorkflowPath(input = {}) {
   if (missing_facts.length) {
     return { ...base, status: 'needs-input', recommendation: null };
   }
-  if (facts.schema_api_change === 'yes' || facts.new_module === 'yes' || facts.uncertainty === 'high') {
-    return ready(base, 'full', 'Risk or uncertainty requires the full workflow.');
+  const riskReasons = riskReasonsFor(facts);
+  if (riskReasons.length) {
+    return ready(base, 'full', 'Risk signals require the user to choose Quick or Full.', riskReasons);
   }
   if (facts.config_doc_only === 'yes' && facts.task_count <= 4 && facts.file_count <= 4) {
     return ready(base, 'tweak', 'Config/doc-only work is within the tweak thresholds.');
@@ -104,14 +109,13 @@ function normalizeLegacyRecord(record) {
   return record;
 }
 
-export function recordWorkflowSelection(changeDir, { mode, reason, confirmed, acknowledged }) {
+export function recordWorkflowSelection(changeDir, { mode, reason, confirmed, acknowledged, verificationStrategy }) {
   const loaded = readWorkflowSelection(changeDir);
   if (!loaded.valid) throw new Error(loaded.failures.join('; '));
   if (loaded.record.status !== 'ready' || !loaded.record.recommendation) {
     throw new Error('workflow recommendation needs more input');
   }
   if (!WORKFLOW_MODES.includes(mode)) throw new Error(`invalid workflow mode: ${mode}`);
-  if (mode === 'quick') throw new Error('quick workflow must use direct acceptance');
   if (confirmed !== true) throw new Error('workflow selection requires --confirm');
   if (!isSafeReason(reason)) {
     throw new Error('workflow selection reason must be non-empty single-line text');
@@ -119,6 +123,14 @@ export function recordWorkflowSelection(changeDir, { mode, reason, confirmed, ac
   const followed = mode === loaded.record.recommendation.mode;
   if (!followed && acknowledged !== true) {
     throw new Error('non-recommended workflow selection requires acknowledgement');
+  }
+  const riskOverride = mode === 'quick' && loaded.record.recommendation.mode !== 'quick';
+  if (mode === 'quick' && (loaded.record.facts.task_count > 3 || loaded.record.facts.file_count > 3
+    || loaded.record.facts.config_doc_only === 'yes')) {
+    throw new Error('Quick is limited to at most 3 non-document code tasks/files; split the change or choose Full');
+  }
+  if (riskOverride && !isVerificationStrategy(verificationStrategy)) {
+    throw new Error('risk-acknowledged Quick selection requires --verification tdd|new-test|bounded');
   }
   const selected = withHash({
     ...withoutHash(loaded.record),
@@ -128,6 +140,8 @@ export function recordWorkflowSelection(changeDir, { mode, reason, confirmed, ac
       followed_recommendation: followed,
       acknowledged_non_recommendation: !followed && acknowledged === true,
       accepted_automatically: false,
+      risk_override: riskOverride,
+      verification_strategy: verificationStrategy ?? (mode === 'quick' ? 'bounded' : null),
       selected_at: new Date().toISOString(),
     },
   });
@@ -135,7 +149,7 @@ export function recordWorkflowSelection(changeDir, { mode, reason, confirmed, ac
   return selected;
 }
 
-export function acceptWorkflowRecommendation(changeDir, { source }) {
+export function acceptWorkflowRecommendation(changeDir, { source, verificationStrategy = 'bounded' }) {
   const loaded = readWorkflowSelection(changeDir);
   if (!loaded.valid) throw new Error(loaded.failures.join('; '));
   const recommendation = loaded.record.recommendation;
@@ -151,6 +165,9 @@ export function acceptWorkflowRecommendation(changeDir, { source }) {
   if (source !== 'direct-request') {
     throw new Error('workflow acceptance source must be direct-request');
   }
+  if (!isVerificationStrategy(verificationStrategy)) {
+    throw new Error('workflow acceptance verification must be tdd, new-test, or bounded');
+  }
 
   const accepted = withHash({
     ...withoutHash(loaded.record),
@@ -160,6 +177,8 @@ export function acceptWorkflowRecommendation(changeDir, { source }) {
       followed_recommendation: true,
       acknowledged_non_recommendation: false,
       accepted_automatically: true,
+      risk_override: false,
+      verification_strategy: verificationStrategy,
       selected_at: new Date().toISOString(),
     },
   });
@@ -171,13 +190,31 @@ export function isDirectWorkflowReceipt(record, state) {
   const selection = record?.selection;
   const mode = selection?.mode;
   if (!['quick', 'hotfix'].includes(mode) || state?.workflow !== mode) return false;
-  if (record?.status !== 'ready' || record?.recommendation?.mode !== mode) return false;
-  if (selection.accepted_automatically !== true || selection.source !== 'direct-request') return false;
+  if (record?.status !== 'ready') return false;
+  const directAcceptance = record?.recommendation?.mode === mode
+    && selection.accepted_automatically === true && selection.source === 'direct-request';
+  const acknowledgedQuick = mode === 'quick' && selection.accepted_automatically === false
+    && selection.risk_override === true && isVerificationStrategy(selection.verification_strategy);
+  if (!directAcceptance && !acknowledgedQuick) return false;
   return mode !== 'hotfix' || record?.facts?.request_kind === 'incident';
 }
 
-function ready(base, mode, reason) {
-  return { ...base, status: 'ready', recommendation: { mode, reasons: [reason] } };
+function ready(base, mode, reason, riskReasons = []) {
+  return { ...base, status: 'ready', recommendation: { mode, reasons: [reason], risk_reasons: riskReasons } };
+}
+
+function riskReasonsFor(facts) {
+  const reasons = [];
+  if (facts.behavioral_constraint_change === 'yes') reasons.push('behavioral constraint changed (PRD, spec, design, data, or permission)');
+  if (facts.schema_api_change === 'yes') reasons.push('schema or API changes');
+  if (facts.new_module === 'yes') reasons.push('new module');
+  if (facts.cross_module_change === 'yes') reasons.push('cross-module change');
+  if (facts.uncertainty === 'high') reasons.push('high uncertainty');
+  return reasons;
+}
+
+function isVerificationStrategy(value) {
+  return ['tdd', 'new-test', 'bounded'].includes(value);
 }
 
 function normalizeCount(value) {

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -84,12 +84,12 @@ Commands:
                         Recover an explicit change context without changing the shell
   runtime check-update  Run a portable update check for canonical skills
   runtime infer <dir>   Infer workflow mode without a plugin-root path
-  workflow recommend <change-dir> [--task-count <n>] [--file-count <n>] [--config-doc-only yes|no|unknown] [--schema-api-change yes|no|unknown] [--new-module yes|no|unknown] [--uncertainty low|high|unknown] [--request-kind standard|incident]
+  workflow recommend <change-dir> [--task-count <n>] [--file-count <n>] [--config-doc-only yes|no|unknown] [--schema-api-change yes|no|unknown] [--new-module yes|no|unknown] [--behavioral-constraint-change yes|no] [--cross-module-change yes|no] [--uncertainty low|high|unknown] [--request-kind standard|incident]
                         Persist observed intake facts and recommend full, hotfix, tweak, or quick without selecting one
-  workflow select <change-dir> --mode full|hotfix|tweak --confirm --reason <text> [--acknowledge-recommendation]
-                        Persist a user-confirmed Full, legacy Hotfix, or Tweak choice; use accept for Quick/direct Hotfix
-  workflow accept <change-dir> --source direct-request
-                        Directly accept a recommended quick or hotfix workflow
+  workflow select <change-dir> --mode full|hotfix|tweak|quick --confirm --reason <text> [--acknowledge-recommendation] [--verification tdd|new-test|bounded]
+                        Persist a user-confirmed path; a risk-acknowledged Quick requires a verification choice
+  workflow accept <change-dir> --source direct-request [--verification tdd|new-test|bounded]
+                        Directly accept a recommended quick or hotfix workflow with bounded verification by default
   workflow show <change-dir> [--json]
                         Show the saved workflow recommendation or selection recovery state
   runtime guard ...     Run a portable phase-transition guard

--- a/scripts/validate-artifacts
+++ b/scripts/validate-artifacts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // validate-artifacts - Validate spec-superflow artifacts
-// Usage: node scripts/validate-artifacts <change-dir>
+// Usage: node scripts/validate-artifacts [change-dir]
 //
 // Reads a change directory and validates all artifacts found:
 //   - proposal.md (change content validation)
@@ -27,12 +27,7 @@ function printReport(label, report) {
 
 function main() {
   const args = process.argv.slice(2);
-  if (args.length < 1) {
-    console.error('Usage: node scripts/validate-artifacts <change-dir>');
-    process.exit(2);
-  }
-
-  const changeDir = args[0];
+  const changeDir = args[0] ?? 'docs/examples/add-dark-mode';
   if (!existsSync(changeDir) || !statSync(changeDir).isDirectory()) {
     console.error(`Error: "${changeDir}" is not a valid directory`);
     process.exit(2);

--- a/skills/build-executor/SKILL.md
+++ b/skills/build-executor/SKILL.md
@@ -35,9 +35,9 @@ For Full and legacy Hotfix, the execution contract is the approved handoff artif
 ### Law 2: TDD Iron Law — Full and legacy Hotfix
 RED (write test, see it fail) → GREEN (write minimal code, see it pass) → REFACTOR (clean up, suite stays green).
 
-Quick may use the closest targeted test or syntax/static check when no behavioral test is appropriate; direct Hotfix must run the original-symptom regression.
+Quick follows the verification strategy persisted in its receipt: `tdd`, `new-test`, or `bounded` (targeted test, syntax/static check, or other stated evidence). A direct Hotfix must still demonstrate that the original symptom is gone.
 
-**Red Flags**: "Quick implementation first, test later" / "Skip the test, manually verify" / "I already know it works" / "Just this one time without tests." ALL mean STOP and write the test first.
+**Red Flags**: ignoring the selected verification strategy, reporting a manual check as if it were automated evidence, or silently expanding a bounded Quick change. Full and legacy Hotfix still require RED → GREEN → REFACTOR.
 
 ### Law 3: Review Before Drift
 Block on: logic defects, spec violations, missing required tests, unintended scope expansion.
@@ -154,7 +154,7 @@ Skip TDD. Apply changes directly. Verify file integrity (exists, non-empty, vali
 
 ## Direct Quick and Hotfix
 
-Quick direct execution requires the valid direct receipt, a bounded diff, targeted tests or syntax/static checks, and a persisted `test_result: pass`; do not create a contract, execution plan, wave review, DP-6, or DP-7. Direct Hotfix follows the same route only for an incident-backed receipt and must run a regression that demonstrates the original symptom is fixed. Stop rather than expanding scope when the boundary is exceeded or verification fails; refresh `workflow recommend` with the observed risk, then select `full --confirm` before resuming. A legacy Hotfix without a direct receipt remains subject to the contract, DP-3, execution plan, and review receipts.
+Quick direct execution requires the valid receipt, a bounded diff, the receipt's selected verification strategy, and a persisted `test_result: pass`; do not create a contract, execution plan, wave review, DP-6, or DP-7. Direct Hotfix follows the same route only for an incident-backed receipt and must run a regression that demonstrates the original symptom is fixed. If scope grows or risk appears, refresh `workflow recommend`, show the revised risk, and wait for the user to choose Quick or Full before resuming. A legacy Hotfix without a direct receipt remains subject to the contract, DP-3, execution plan, and review receipts.
 
 ## DP Records
 

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -48,7 +48,7 @@ npx --yes --package spec-superflow@0.11.0 ssf workflow recommend <change-dir> --
 npx --yes --package spec-superflow@0.11.0 ssf workflow accept <change-dir> --source direct-request
 ```
 
-Quick is ≤3 tasks/files of low-risk code. Hotfix is an incident with a reproducible symptom and ≤2 tasks/files. Display `Observed`, `Recommended`, and `Why`; acceptance is the user's direct request to proceed. Do not create planning artifacts, a contract, an execution plan, wave receipts, or DP approvals. Transition through the receipt-aware guard, execute bounded work, and require `test_result: pass` before closing. Any fourth file, public/schema/API boundary, new module, dependency/permission/data change, high uncertainty, or failed verification stops the path: refresh `workflow recommend` with those facts, then select `full --confirm` before continuing. A legacy Hotfix without a valid direct receipt remains on the Full contract/DP-3/plan/review path.
+Quick is ≤3 tasks/files of low-risk code. Hotfix is an incident with a reproducible symptom and ≤2 tasks/files. Display `Observed`, `Recommended`, `Why`, and any risk reasons; acceptance is the user's direct request to proceed. Do not create planning artifacts, a contract, an execution plan, wave receipts, or DP approvals. Transition through the receipt-aware guard, execute bounded work, and require `test_result: pass` before closing. A fourth code file, behavioral-constraint change (PRD/spec/design/API/data/permission), cross-module work, a new module, high uncertainty, or failed verification does not auto-escalate: show Quick and Full, then wait for the user's choice. A user selecting Quick must acknowledge the recommendation and choose `tdd`, `new-test`, or `bounded` verification in the receipt. A legacy Hotfix without a valid direct receipt remains on the Full contract/DP-3/plan/review path.
 
 ## DP-0: User Confirmation Gate
 
@@ -100,10 +100,10 @@ state or cause a phase transition.
 6. Run `npx --yes --package spec-superflow@0.11.0 ssf workflow recommend <change-dir> ...` once with one complete fact snapshot.
 7. Show the user `Observed`, `Available`, `Recommended`, and `Why`. A
    recommendation is advice only: never persist it as the workflow selection.
-8. A recommended Quick or incident Hotfix is accepted only with
+8. A recommended low-risk Quick or incident Hotfix is accepted only with
    `npx --yes --package spec-superflow@0.11.0 ssf workflow accept <change-dir> --source direct-request`.
    For Full, legacy Hotfix, or Tweak, obtain the user's explicit choice and run
-   `npx --yes --package spec-superflow@0.11.0 ssf workflow select <change-dir> --mode <full|hotfix|tweak> --confirm --reason "<user choice>"`.
+   `npx --yes --package spec-superflow@0.11.0 ssf workflow select <change-dir> --mode <full|hotfix|tweak> --confirm --reason "<user choice>"`. For a risk-signalled Quick choice, run `workflow select --mode quick --confirm --acknowledge-recommendation --verification <tdd|new-test|bounded>`.
 9. Add `--acknowledge-recommendation` only after the user chooses a
    non-recommended selectable path. Report the persisted receipt and DP-0 audit summary.
 10. To escalate a selected Quick, direct Hotfix, or Tweak, refresh

--- a/tests/lib/cmd-validate-paths.test.mjs
+++ b/tests/lib/cmd-validate-paths.test.mjs
@@ -37,6 +37,13 @@ describe('validate commands: spec paths', () => {
     if (tempRoot) rmSync(tempRoot, { recursive: true, force: true });
   });
 
+  it('validate-artifacts uses the bundled add-dark-mode example by default', () => {
+    const result = runNode([LEGACY]);
+    assert.equal(result.exitCode, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, /Change: add-dark-mode/);
+    assert.match(result.stdout, /All artifacts validated successfully/);
+  });
+
   it('ssf validate rejects flat specs/<capability>.md', () => {
     const dir = mkdtempSync(join(tempRoot, 'flat-'));
     writeBaseChange(dir);

--- a/tests/lib/cmd-workflow.test.mjs
+++ b/tests/lib/cmd-workflow.test.mjs
@@ -68,11 +68,10 @@ afterEach(() => {
 });
 
 describe('ssf workflow', () => {
-  it('advertises direct acceptance instead of selectable Quick in global help', () => {
+  it('advertises both direct acceptance and an explicit risk-acknowledged Quick selection', () => {
     const result = runSsf(['--help']);
     assert.equal(result.exitCode, 0, result.stderr);
-    assert.match(result.stdout, /workflow select .*full\|hotfix\|tweak/);
-    assert.doesNotMatch(result.stdout, /workflow select .*quick/);
+    assert.match(result.stdout, /workflow select .*full\|hotfix\|tweak\|quick/);
     assert.match(result.stdout, /workflow accept <change-dir> --source direct-request/);
   });
 
@@ -96,24 +95,34 @@ describe('ssf workflow', () => {
     const recommended = recommend(['--request-kind', 'incident']);
     assert.equal(recommended.exitCode, 0, recommended.stderr);
     assert.equal(recommended.json.recommendation.mode, 'hotfix');
-    const accepted = runSsf(['workflow', 'accept', changeDir, '--source', 'direct-request', '--json']);
+    const accepted = runSsf(['workflow', 'accept', changeDir, '--source', 'direct-request', '--verification', 'new-test', '--json']);
     assert.equal(accepted.exitCode, 0, accepted.stderr);
     assert.equal(readState(changeDir).workflow, 'hotfix');
+    assert.equal(accepted.json.record.selection.verification_strategy, 'new-test');
   });
 
-  it('rejects a selectable Quick path and leaves the direct receipt boundary intact', () => {
-    const recommended = recommend();
+  it('allows a risk-acknowledged Quick selection only with a user-chosen verification strategy', () => {
+    const recommended = recommend(['--behavioral-constraint-change', 'yes']);
     assert.equal(recommended.exitCode, 0, recommended.stderr);
-    assert.equal(recommended.json.recommendation.mode, 'quick');
+    assert.equal(recommended.json.recommendation.mode, 'full');
     assert.equal(readState(changeDir).workflow, 'auto');
 
-    const before = snapshotWorkflowFiles();
+    const rejected = runSsf(['workflow', 'select', changeDir, '--mode', 'quick',
+      '--confirm', '--reason', 'bounded code fix', '--acknowledge-recommendation', '--json']);
+    assert.equal(rejected.exitCode, 1);
+    assert.match(rejected.stderr, /verification/i);
+
     const selected = runSsf(['workflow', 'select', changeDir, '--mode', 'quick',
-      '--confirm', '--reason', 'bounded code fix', '--json']);
-    assert.equal(selected.exitCode, 2);
-    assert.match(selected.stderr, /full, hotfix, tweak/i);
-    assertWorkflowFilesUnchanged(before);
-    assert.equal(readState(changeDir).dp_0_decisions, null);
+      '--confirm', '--reason', 'user accepts the documented API risk',
+      '--acknowledge-recommendation', '--verification', 'new-test', '--json']);
+    assert.equal(selected.exitCode, 0, selected.stderr);
+    assert.equal(selected.json.record.selection.risk_override, true);
+    assert.equal(selected.json.record.selection.verification_strategy, 'new-test');
+    assert.equal(readState(changeDir).workflow, 'quick');
+
+    const guard = runSsf(['runtime', 'guard', 'check', changeDir, 'exploring', 'approved-for-build', '--workflow', 'quick', '--json']);
+    assert.equal(guard.exitCode, 0, guard.stderr);
+    assert.equal(guard.json.pass, true);
   });
 
   it('refreshes a direct Quick recommendation and escalates to Full when risk grows', () => {
@@ -131,6 +140,21 @@ describe('ssf workflow', () => {
     assert.equal(upgraded.exitCode, 0, upgraded.stderr);
     assert.equal(readState(changeDir).workflow, 'full');
     assert.equal(upgraded.json.record.selection.mode, 'full');
+  });
+
+  it('never permits a four-file change to override into Quick', () => {
+    const recommended = runSsf(['workflow', 'recommend', changeDir,
+      '--task-count', '4', '--file-count', '4', '--config-doc-only', 'no',
+      '--schema-api-change', 'no', '--new-module', 'no', '--uncertainty', 'low', '--json']);
+    assert.equal(recommended.exitCode, 0, recommended.stderr);
+    assert.equal(recommended.json.recommendation.mode, 'full');
+
+    const selected = runSsf(['workflow', 'select', changeDir, '--mode', 'quick',
+      '--confirm', '--reason', 'try to keep this light', '--acknowledge-recommendation',
+      '--verification', 'bounded', '--json']);
+    assert.equal(selected.exitCode, 1);
+    assert.match(selected.stderr, /at most 3/i);
+    assert.equal(readState(changeDir).workflow, 'auto');
   });
 
   it('shows complete ready recommendations in human-readable recommend and show output', () => {

--- a/tests/lib/workflow-recommendation.test.mjs
+++ b/tests/lib/workflow-recommendation.test.mjs
@@ -149,13 +149,19 @@ describe('workflow path recommendation', () => {
     }
   });
 
-  it('requires direct acceptance for the Quick workflow', () => {
+  it('requires an acknowledged verification strategy for a risk-acknowledged Quick workflow', () => {
     const changeDir = mkdtempSync(join(tmpdir(), 'ssf-workflow-quick-'));
     try {
-      saveWorkflowRecommendation(changeDir, base);
+      saveWorkflowRecommendation(changeDir, { ...base, behavioral_constraint_change: 'yes' });
       assert.throws(() => recordWorkflowSelection(changeDir, {
-        mode: 'quick', reason: 'bounded code', confirmed: true, acknowledged: false,
-      }), /direct acceptance/i);
+        mode: 'quick', reason: 'bounded code', confirmed: true, acknowledged: true,
+      }), /verification/i);
+      const selected = recordWorkflowSelection(changeDir, {
+        mode: 'quick', reason: 'bounded code', confirmed: true, acknowledged: true,
+        verificationStrategy: 'bounded',
+      });
+      assert.equal(selected.selection.risk_override, true);
+      assert.equal(selected.selection.verification_strategy, 'bounded');
     } finally {
       rmSync(changeDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- let risk signals prompt a Quick-or-Full choice instead of auto-escalating
- record the selected TDD, new-test, or bounded verification strategy
- document all four workflow paths and fix the default validation command

## Verification
- npm run build
- npm test
- npm run validate
- node --test tests/lib/cmd-validate-paths.test.mjs

Version remains 0.11.0; release v0.12.0 is intentionally deferred.