### PR TITLE
chore: prepare v0.12.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.11.0 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.12.0 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-27
+
+### Added
+
+- **User-controlled lightweight workflow paths**: Workflow recommendations now surface behavioral-constraint, API/schema, cross-module, new-module, and uncertainty risks without automatically escalating. Users can explicitly retain Quick for an eligible three-file single-module change by acknowledging the risk and recording `tdd`, `new-test`, or `bounded` verification.
+- **Clearer four-mode guidance**: Quick, direct Hotfix, Tweak, and Full now document their file boundaries, decision points, and verification expectations consistently across the CLI, skills, and installation guidance.
+
+### Fixed
+
+- **Default artifact validation**: `npm run validate` now validates the bundled `docs/examples/add-dark-mode` example when no change directory is supplied, while retaining explicit-directory validation.
+
 ## [0.11.0] - 2026-07-21
 
 ### Added

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.11.0 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v0.12.0 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.11.0**。
+当前发布版本：**v0.12.0**。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v0.11.0`
+- 当前版本：`v0.12.0`
 - v0.9.1 highlights：DP-4 执行模式推荐、跨 17 个平台的 portable runtime，以及无插件根路径的 raw-package smoke；详见 [CHANGELOG.md](CHANGELOG.md)
 - v0.9.0 highlights：支持 Node 20/22、model profiles 只读解析，以及 code-reviewer 的最小性审查
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers

--- a/commands/ssf/resume.md
+++ b/commands/ssf/resume.md
@@ -5,6 +5,6 @@ argument-hint: "[change-name-or-path]"
 allowed-tools: Bash(npx:*)
 ---
 
-先检查 `$ARGUMENTS` 是否为非空目标：为空时运行 `npx --yes --package spec-superflow@0.11.0 ssf resume --json`，让 CLI 按唯一活跃 change 的既有确定性规则选择；非空时运行 `npx --yes --package spec-superflow@0.11.0 ssf resume --json "$ARGUMENTS"`，将整个目标作为单一字面参数。
+先检查 `$ARGUMENTS` 是否为非空目标：为空时运行 `npx --yes --package spec-superflow@0.12.0 ssf resume --json`，让 CLI 按唯一活跃 change 的既有确定性规则选择；非空时运行 `npx --yes --package spec-superflow@0.12.0 ssf resume --json "$ARGUMENTS"`，将整个目标作为单一字面参数。
 
 只使用返回的 `change`、`blockers` 和 `next_action`：存在 blocker 时停止并展示修复命令；否则通过 `workflow-start` 进入 `next_action` 指定的下一 skill。不要直接修改状态文件。

--- a/commands/ssf/save.md
+++ b/commands/ssf/save.md
@@ -7,4 +7,4 @@ allowed-tools: Bash(npx:*)
 
 只把 `$ARGUMENTS` 作为对话输入，从中提取明确的 change、task 和 next，以及用户明确提供的可选 evidence 字段。信息不足时先询问一次；不要编造 verification 或 review 证据。
 
-确认参数后运行 `npx --yes --package spec-superflow@0.11.0 ssf save "<change>" --task "<task-id>" --next "<next-step>" [--completed "<completed>"] [--verification "<verification>"] [--review "<review>"] [--risk "<risk>"] [--commit-start "<commit-start>"] [--commit-end "<commit-end>"] --json`。每个值必须来自已提取或已确认的信息，并作为单独引用的字面参数传入。只报告 CLI 返回的 checkpoint 结果，并保留现有状态机和存储边界。
+确认参数后运行 `npx --yes --package spec-superflow@0.12.0 ssf save "<change>" --task "<task-id>" --next "<next-step>" [--completed "<completed>"] [--verification "<verification>"] [--review "<review>"] [--risk "<risk>"] [--commit-start "<commit-start>"] [--commit-end "<commit-end>"] --json`。每个值必须来自已提取或已确认的信息，并作为单独引用的字面参数传入。只报告 CLI 返回的 checkpoint 结果，并保留现有状态机和存储边界。

--- a/commands/ssf/switch.md
+++ b/commands/ssf/switch.md
@@ -7,4 +7,4 @@ allowed-tools: Bash(npx:*)
 
 `$ARGUMENTS` 必须提供一个非空的 change 名称或路径；若未提供，先询问用户选择哪个 change。
 
-确认目标非空后运行 `npx --yes --package spec-superflow@0.11.0 ssf switch --json "$ARGUMENTS"`，将整个目标作为单一字面参数。只使用返回的恢复上下文切换当前对话的关注对象。存在 blocker 时停止并展示修复命令；不得改变文件、工作目录或任何隐藏指针。
+确认目标非空后运行 `npx --yes --package spec-superflow@0.12.0 ssf switch --json "$ARGUMENTS"`，将整个目标作为单一字面参数。只使用返回的恢复上下文切换当前对话的关注对象。存在 blocker 时停止并展示修复命令；不得改变文件、工作目录或任何隐藏指针。

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -129,7 +129,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.11.0`
+- Current: `v0.12.0`
 - v0.9.1 highlights: DP-4 execution-mode recommendations, a portable runtime across 17 platforms, and a raw-package smoke with no plugin-root variable.
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.11.0: conditional injection — detects artifacts, injects workflow-start pointer
+# v0.12.0: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Three platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.11.0.
+Current version: v0.12.0.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/skills/bug-investigator/SKILL.md
+++ b/skills/bug-investigator/SKILL.md
@@ -49,7 +49,7 @@ Scientific method: form a single hypothesis ("I think X is the root cause becaus
 
 ### DP-5: Debug Escalation (3+ Failures)
 
-3+ failed fixes = architectural problem. Each fix revealing new problems elsewhere = wrong architecture. Record: `npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_5_result <decision>`. Discuss with user before attempting more fixes.
+3+ failed fixes = architectural problem. Each fix revealing new problems elsewhere = wrong architecture. Record: `npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_5_result <decision>`. Discuss with user before attempting more fixes.
 
 ## Red Flags — Return to Phase 1
 

--- a/skills/build-executor/SKILL.md
+++ b/skills/build-executor/SKILL.md
@@ -16,13 +16,13 @@ Check workflow mode and receipt first. Tweak → direct edit mode. Quick or a va
 Branch/worktree preflight before ANY implementation edit (mandatory — do not skip):
 1. Run the isolation check:
    ```bash
-   npx --yes --package spec-superflow@0.11.0 ssf isolate <change-dir>
+   npx --yes --package spec-superflow@0.12.0 ssf isolate <change-dir>
    ```
    This script enforces git isolation: if you are on `main`/`master` it creates a
    git worktree (preferred) or a new branch, and exits non-zero if it cannot and you
    have not approved `--force`.
-2. If `npx --yes --package spec-superflow@0.11.0 ssf isolate` exits non-zero: STOP. Do not edit `main`/`master` in place.
-   Ask the user for explicit approval (and re-run with `npx --yes --package spec-superflow@0.11.0 ssf isolate <change-dir> --force`
+2. If `npx --yes --package spec-superflow@0.12.0 ssf isolate` exits non-zero: STOP. Do not edit `main`/`master` in place.
+   Ask the user for explicit approval (and re-run with `npx --yes --package spec-superflow@0.12.0 ssf isolate <change-dir> --force`
    only after they approve).
 3. If it succeeds, report the chosen branch/worktree and make all implementation
    edits there.
@@ -53,15 +53,15 @@ For Quick/direct Hotfix, stop instead of creating or rewinding a contract; refre
 For Full or legacy Hotfix, generate proposed waves from the approved contract, then use the recommendation as a decision aid rather than silently defaulting a mode:
 
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf execution recommend <change-dir> \
+npx --yes --package spec-superflow@0.12.0 ssf execution recommend <change-dir> \
   --wave <wave-id>:<parallel|serial>:<task,...>[:<depends-on,...>] --json
 # Show every available mode, the observed facts, and the recommendation to the user.
 # The command writes a receipt tied to the artifacts, contract, and waves. After the user chooses, record that explicit confirmation:
-npx --yes --package spec-superflow@0.11.0 ssf execution plan <change-dir> \
+npx --yes --package spec-superflow@0.12.0 ssf execution plan <change-dir> \
   --mode <selected-mode> --confirm --reason "user-selected execution mode" \
   --wave <wave-id>:<parallel|serial>:<task,...>[:<depends-on,...>]
 # Add --acknowledge-recommendation when the selection differs from the recommendation.
-npx --yes --package spec-superflow@0.11.0 ssf execution show <change-dir> --json
+npx --yes --package spec-superflow@0.12.0 ssf execution show <change-dir> --json
 ```
 
 The optional fourth `--wave` segment names prerequisite wave IDs. `execution show --json` reports `current`, plus each wave's `depends_on`, `receipt`, `blockers`, `retryable`, and `eligible` status. A wave with `retryable: true` has a current `fail` receipt and is eligible only for its focused repair and re-review; its dependents remain blocked until its replacement `pass` receipt. Report the saved plan revision, selected mode, ordered waves, dependencies, and whether every `parallel` wave can actually be dispatched concurrently on the current platform. If concurrency is unavailable, state the capability and reason plainly; retain the planned `parallel` strategy and do not silently execute it as a serial or Batch Inline plan.
@@ -74,7 +74,7 @@ The recommendation uses task count, configured `execution.inlineThreshold`, and 
 | **Inline** | Recommended for a single sequential task; always available for a user-confirmed choice |
 | **Batch Inline** | Recommended for a bounded sequential batch; it remains serial and is never presented as parallel |
 
-Do not transition to `executing` until `execution show` reports `current: true` and the phase guard passes. A revised plan must repeat `npx --yes --package spec-superflow@0.11.0 ssf execution recommend` and use `npx --yes --package spec-superflow@0.11.0 ssf execution revise --confirm`; it creates a new revision and invalidates receipts from the prior revision.
+Do not transition to `executing` until `execution show` reports `current: true` and the phase guard passes. A revised plan must repeat `npx --yes --package spec-superflow@0.12.0 ssf execution recommend` and use `npx --yes --package spec-superflow@0.12.0 ssf execution revise --confirm`; it creates a new revision and invalidates receipts from the prior revision.
 
 ## Batch Inline Execution
 
@@ -89,21 +89,21 @@ Boundaries: if any task touches >1 module, involves schema/API/config changes, o
 For Full/legacy Hotfix by default. Dispatch according to the persisted plan, review each planned wave, and run a final broad review after all waves.
 
 ### Planned-Wave Loop
-1. Read the current plan with `npx --yes --package spec-superflow@0.11.0 ssf execution show <change-dir> --json`; only waves shown with `current: true` and `eligible: true` may start. A `retryable: true` wave may only be repaired and re-reviewed; do not dispatch its dependents until its replacement receipt is `pass`. The CLI encodes dependencies in `--wave <id>:<strategy>:<tasks>[:<depends-on,...>]` and rejects a review receipt for a wave whose prerequisites lack current `pass` receipts.
+1. Read the current plan with `npx --yes --package spec-superflow@0.12.0 ssf execution show <change-dir> --json`; only waves shown with `current: true` and `eligible: true` may start. A `retryable: true` wave may only be repaired and re-reviewed; do not dispatch its dependents until its replacement receipt is `pass`. The CLI encodes dependencies in `--wave <id>:<strategy>:<tasks>[:<depends-on,...>]` and rejects a review receipt for a wave whose prerequisites lack current `pass` receipts.
 2. A `parallel` wave may dispatch independent tasks simultaneously only when the platform supports concurrent dispatch. If it does not, disclose the unavailable capability and execute the same wave one task at a time without changing its stored strategy.
 3. A `serial` wave dispatches one task at a time in listed order.
 4. After every wave, write a non-empty persisted regular-file review report (separate from the implementer's report), then record exactly one receipt that names that review report:
    ```bash
-   npx --yes --package spec-superflow@0.11.0 ssf execution review <change-dir> \
+   npx --yes --package spec-superflow@0.12.0 ssf execution review <change-dir> \
      --wave <wave-id> --base <sha> --head <sha> --report <review-report-path> --verdict <pass|fail>
    ```
    Do not begin a dependent wave until its predecessor receipt is `pass`.
 5. Critical/Important findings require a `fail` receipt, a focused repair, re-review, then a replacement `pass` receipt. Never advance or close with a missing or failed receipt.
 
 ### Per-Task Loop
-1. **Dispatch implementer**: Load the template with `npx --yes --package spec-superflow@0.11.0 ssf runtime asset read skills/build-executor/implementer-prompt.md`. Extract task brief with `scripts/task-brief PLAN_FILE N`. Include: where task fits, brief path, interfaces from prior tasks, report file path.
+1. **Dispatch implementer**: Load the template with `npx --yes --package spec-superflow@0.12.0 ssf runtime asset read skills/build-executor/implementer-prompt.md`. Extract task brief with `scripts/task-brief PLAN_FILE N`. Include: where task fits, brief path, interfaces from prior tasks, report file path.
 2. **Handle response**: DONE → generate review package + dispatch reviewer. DONE_WITH_CONCERNS → assess. NEEDS_CONTEXT → provide context. BLOCKED → re-dispatch with better model or escalate.
-3. **Review**: Load `npx --yes --package spec-superflow@0.11.0 ssf runtime asset read skills/build-executor/task-reviewer-prompt.md`. Reviewer returns spec compliance + code quality verdicts with the wave ID, git range, report path, and `pass`/`fail` receipt command.
+3. **Review**: Load `npx --yes --package spec-superflow@0.12.0 ssf runtime asset read skills/build-executor/task-reviewer-prompt.md`. Reviewer returns spec compliance + code quality verdicts with the wave ID, git range, report path, and `pass`/`fail` receipt command.
 4. **Fix**: If Critical or Important issues, write the `fail` receipt, dispatch fix subagent, re-review, and write the replacement `pass` receipt.
 5. **Mark complete**: Append to `.superpowers/sdd/progress.md`: `Task N: complete (commits <base7>..<head7>, review clean)`
 
@@ -111,7 +111,7 @@ For Full/legacy Hotfix by default. Dispatch according to the persisted plan, rev
 Use the configured profile that matches the task role. Resolve it before dispatch:
 
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf runtime config --resolve-model <profile>
+npx --yes --package spec-superflow@0.12.0 ssf runtime config --resolve-model <profile>
 ```
 
 | Profile | Role |
@@ -124,11 +124,11 @@ npx --yes --package spec-superflow@0.11.0 ssf runtime config --resolve-model <pr
 For platforms whose dispatch supports a `model` field, explicitly pass the resolved `model` value. If the result is `configured: false`, automatic selection is unavailable: do not invent a provider model and do not bypass the existing requirement to specify `model` explicitly. Resolution only reads configuration; it does not switch models.
 
 ### Progress Ledger
-Track in `.superpowers/sdd/progress.md`. Check for existing ledger — completed tasks are done. After each batch: `npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> batches_completed <N>`.
+Track in `.superpowers/sdd/progress.md`. Check for existing ledger — completed tasks are done. After each batch: `npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> batches_completed <N>`.
 
 ## Inline Execution Mode
 
-Only after a user-confirmed `inline` selection is recorded by `npx --yes --package spec-superflow@0.11.0 ssf execution plan --confirm`; a non-recommended selection also records `--acknowledge-recommendation`. Executes in the current session and still writes one review receipt per planned wave.
+Only after a user-confirmed `inline` selection is recorded by `npx --yes --package spec-superflow@0.12.0 ssf execution plan --confirm`; a non-recommended selection also records `--acknowledge-recommendation`. Executes in the current session and still writes one review receipt per planned wave.
 
 Per-task: extract brief → write failing test → confirm failure → implement → confirm green → checkpoint review (done-when criteria, SHALL/MUST verification) → commit → save a task-level recovery checkpoint when another task remains → append to progress ledger.
 
@@ -136,7 +136,7 @@ After a task is committed and reviewed, when another task remains, save the
 recovery context with real evidence:
 
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf checkpoint save <change-dir> \
+npx --yes --package spec-superflow@0.12.0 ssf checkpoint save <change-dir> \
   --task <completed-task-id> --next "<next task>" --completed "<completed work>" \
   --verification "<verification report path>" --review "<review report path>" \
   --risk "<open risk or None>" --commit-start <base-sha> --commit-end <head-sha>
@@ -144,7 +144,7 @@ npx --yes --package spec-superflow@0.11.0 ssf checkpoint save <change-dir> \
 
 This augments `.superpowers/sdd/progress.md`; it does not replace the progress
 ledger or add a new core workflow state. Do not claim a checkpoint is current
-when `npx --yes --package spec-superflow@0.11.0 ssf checkpoint list` reports it as stale.
+when `npx --yes --package spec-superflow@0.12.0 ssf checkpoint list` reports it as stale.
 
 If task hits BLOCKED (3+ fix failures or changes outside declared scope), escalate to SDD.
 
@@ -158,8 +158,8 @@ Quick direct execution requires the valid receipt, a bounded diff, the receipt's
 
 ## DP Records
 
-DP-4 is written by `npx --yes --package spec-superflow@0.11.0 ssf execution plan`; do not write it with raw `state set`.
-DP-5 (debug escalation): `npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_5_result "<resolution>"` + timestamp.
+DP-4 is written by `npx --yes --package spec-superflow@0.12.0 ssf execution plan`; do not write it with raw `state set`.
+DP-5 (debug escalation): `npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_5_result "<resolution>"` + timestamp.
 
 ## Completion Standard
 

--- a/skills/build-executor/implementer-prompt.md
+++ b/skills/build-executor/implementer-prompt.md
@@ -22,7 +22,7 @@ Subagent (general-purpose):
     ## Planned Wave
 
     You are assigned to planned wave [WAVE_ID] with strategy [WAVE_STRATEGY].
-    Read `npx --yes --package spec-superflow@0.11.0 ssf execution show <change-dir> --json` before editing. Do not start
+    Read `npx --yes --package spec-superflow@0.12.0 ssf execution show <change-dir> --json` before editing. Do not start
     unless all declared dependencies have `pass` review receipts. A `parallel`
     label permits concurrent dispatch only when the controller confirms the
     platform supports it; never change the saved wave strategy yourself.

--- a/skills/build-executor/task-reviewer-prompt.md
+++ b/skills/build-executor/task-reviewer-prompt.md
@@ -146,7 +146,7 @@ Subagent (general-purpose):
     command for the controller:
 
     ```bash
-    npx --yes --package spec-superflow@0.11.0 ssf execution review <change-dir> --wave [WAVE_ID] --base [BASE_SHA] --head [HEAD_SHA] --report [REVIEW_REPORT_FILE] --verdict <pass|fail>
+    npx --yes --package spec-superflow@0.12.0 ssf execution review <change-dir> --wave [WAVE_ID] --base [BASE_SHA] --head [HEAD_SHA] --report [REVIEW_REPORT_FILE] --verdict <pass|fail>
     ```
 
     Use `fail` for any Critical/Important finding. A repair must be re-reviewed

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -16,7 +16,7 @@ Two responsibilities: requesting review (dispatching a reviewer subagent) and re
 1. Get SHAs: `BASE_SHA=$(git rev-parse HEAD~1)` and `HEAD_SHA=$(git rev-parse HEAD)`
 2. Dispatch `general-purpose` subagent using template at `skills/code-reviewer/code-reviewer-prompt.md`
 3. Fill placeholders: `[DESCRIPTION]` (what was built), `[PLAN_OR_REQUIREMENTS]` (contract/spec reference), `[BASE_SHA]`, `[HEAD_SHA]`, `[WAVE_ID]`, and a distinct `[REVIEW_REPORT_FILE]`.
-4. Require the reviewer to write a non-empty persisted review report at `[REVIEW_REPORT_FILE]`, then record that exact path in the wave receipt: `npx --yes --package spec-superflow@0.11.0 ssf execution review <change-dir> --wave <id> --base <sha> --head <sha> --report <review-report-path> --verdict <pass|fail>`.
+4. Require the reviewer to write a non-empty persisted review report at `[REVIEW_REPORT_FILE]`, then record that exact path in the wave receipt: `npx --yes --package spec-superflow@0.12.0 ssf execution review <change-dir> --wave <id> --base <sha> --head <sha> --report <review-report-path> --verdict <pass|fail>`.
 5. Act on feedback: Critical/Important findings require a `fail` receipt, focused repair, re-review, and replacement `pass` receipt before a dependent wave or closing can proceed. Note Minor for later, push back with reasoning if reviewer is wrong.
 
 ### Minimality And Scope
@@ -72,7 +72,7 @@ Suggestion breaks existing functionality, reviewer lacks context, violates YAGNI
 | Performative agreement | State requirement or just act |
 | Blind implementation | Verify against codebase first |
 | Batch without testing | One at a time, test each |
-| Proceeding without a wave receipt | Record `pass`/`fail` via `npx --yes --package spec-superflow@0.11.0 ssf execution review` before the next dependent wave |
+| Proceeding without a wave receipt | Record `pass`/`fail` via `npx --yes --package spec-superflow@0.12.0 ssf execution review` before the next dependent wave |
 | Assuming reviewer is right | Check if breaks things |
 | Avoiding pushback | Technical correctness > comfort |
 | Partial implementation | Clarify all items first |

--- a/skills/code-reviewer/code-reviewer-prompt.md
+++ b/skills/code-reviewer/code-reviewer-prompt.md
@@ -93,7 +93,7 @@ Subagent (general-purpose):
     report path. End with the exact receipt command:
 
     ```bash
-    npx --yes --package spec-superflow@0.11.0 ssf execution review <change-dir> --wave [WAVE_ID] --base [BASE_SHA] --head [HEAD_SHA] --report [REVIEW_REPORT_FILE] --verdict <pass|fail>
+    npx --yes --package spec-superflow@0.12.0 ssf execution review <change-dir> --wave [WAVE_ID] --base [BASE_SHA] --head [HEAD_SHA] --report [REVIEW_REPORT_FILE] --verdict <pass|fail>
     ```
 
     Use `fail` when any Critical or Important finding remains. A repair needs

--- a/skills/contract-builder/SKILL.md
+++ b/skills/contract-builder/SKILL.md
@@ -5,11 +5,11 @@ description: Convert approved planning artifacts into an execution contract. Inv
 
 # Contract Builder
 
-Converts planning artifacts into a single execution handshake: `execution-contract.md`. Load the baseline with `npx --yes --package spec-superflow@0.11.0 ssf runtime asset read templates/execution-contract.md`.
+Converts planning artifacts into a single execution handshake: `execution-contract.md`. Load the baseline with `npx --yes --package spec-superflow@0.12.0 ssf runtime asset read templates/execution-contract.md`.
 
 Read before generating: `.spec-superflow.yaml` (especially `dp_0_decisions`),
 `proposal.md`, `specs/`, `design.md`, `tasks.md`, then load
-`docs/artifact-contract.md` with `npx --yes --package spec-superflow@0.11.0 ssf runtime asset read docs/artifact-contract.md`.
+`docs/artifact-contract.md` with `npx --yes --package spec-superflow@0.12.0 ssf runtime asset read docs/artifact-contract.md`.
 
 ## Artifact Language
 
@@ -47,8 +47,8 @@ Must make obvious: approved behavior, out-of-scope, constraints, batches, test o
 
 After drafting: summarize handoff rules, identify ambiguity, flag unmapped requirements, ask user to approve explicitly. After approval:
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_3_result "approved: <summary>"
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_3_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_3_result "approved: <summary>"
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_3_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 DP-3 is a hard gate — no implementation without this record.
 
@@ -69,9 +69,9 @@ Generate a minimal contract only for a legacy Hotfix: Intent Lock (one sentence)
 
 ## Post-Generation
 
-Run `npx --yes --package spec-superflow@0.11.0 ssf state init <change-dir>` to create `.spec-superflow.yaml` with hashes.
+Run `npx --yes --package spec-superflow@0.12.0 ssf state init <change-dir>` to create `.spec-superflow.yaml` with hashes.
 
-For a legacy Hotfix, after writing the minimal contract, run `npx --yes --package spec-superflow@0.11.0 ssf state init <change-dir>` or `npx --yes --package spec-superflow@0.11.0 ssf state rebuild <change-dir>` so `contract_hash` is recorded. DP-3 remains mandatory before build.
+For a legacy Hotfix, after writing the minimal contract, run `npx --yes --package spec-superflow@0.12.0 ssf state init <change-dir>` or `npx --yes --package spec-superflow@0.12.0 ssf state rebuild <change-dir>` so `contract_hash` is recorded. DP-3 remains mandatory before build.
 
 ## Exception Handling
 

--- a/skills/need-explorer/SKILL.md
+++ b/skills/need-explorer/SKILL.md
@@ -37,8 +37,8 @@ Restate what you heard: "Here's what I'm hearing: [problem, scope, non-goals, su
 
 After user confirms the summary:
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_1_result "confirmed: <one-line summary>"
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_1_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_1_result "confirmed: <one-line summary>"
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_1_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 DP-1 confirms scope, non-goals, and success criteria before artifact creation.
 

--- a/skills/release-archivist/SKILL.md
+++ b/skills/release-archivist/SKILL.md
@@ -12,7 +12,7 @@ the final transition to `closing`.
 ## Execution-State Guard
 
 Before verification, `ssf audit`, any DP state write, or delta-spec merge, run
-`npx --yes --package spec-superflow@0.11.0 ssf state get <change-dir> state`.
+`npx --yes --package spec-superflow@0.12.0 ssf state get <change-dir> state`.
 Continue only when the persisted state is exactly `executing`. If it is
 `closing` → STOP: "Closing is terminal; release, audit, and archival work were
 completed before this transition." For any other state, or if the state cannot
@@ -77,12 +77,12 @@ Check for files modified outside scope fence, new dependencies not in design. Un
 - Scope added without artifact updates?
 - Unresolved blockers or known risks?
 - Delta specs exist that need merging?
-- Run `npx --yes --package spec-superflow@0.11.0 ssf audit <change-dir>` — include `decision-point-audit.md` in archive
+- Run `npx --yes --package spec-superflow@0.12.0 ssf audit <change-dir>` — include `decision-point-audit.md` in archive
 
 ### DP-6 (Verification Outcome, Full/legacy Hotfix)
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_6_result "<pass|conditional|fail>: <summary>"
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_6_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_6_result "<pass|conditional|fail>: <summary>"
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_6_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 If FAIL, do NOT proceed to DP-7. Route back or ask about abandonment.
 
@@ -90,13 +90,13 @@ After recording a PASS outcome, also record it as the verification gate so the
 `executing → closing` transition is allowed (the guard accepts either
 `test_result: pass` or a `dp_6_result` starting with `pass`):
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> test_result pass
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> test_result pass
 ```
 
 ### DP-7 (Archive Confirmation, Full/legacy Hotfix)
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_7_result "confirmed: <archive summary>"
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_7_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_7_result "confirmed: <archive summary>"
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_7_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 Verify DP-0 through DP-6 are recorded before DP-7.
 
@@ -109,7 +109,7 @@ If implementation diverged from the contract, return to `bridging` before closur
 Complete every release, delta-spec synchronization, and audit action while the
 state remains `executing`. If delta specs exist, invoke `spec-merger` and
 resolve its outcome before the final `executing → closing` transition. Then
-run `npx --yes --package spec-superflow@0.11.0 ssf state transition <change-dir> closing`.
+run `npx --yes --package spec-superflow@0.12.0 ssf state transition <change-dir> closing`.
 `executing → closing` is the final action: once it succeeds, select no next
 skill and run no recovery scans.
 
@@ -120,6 +120,6 @@ Quick and direct Hotfix use a concise verification summary: changed files, focus
 ## Exception Handling
 
 - **Parse failures**: Report exact file and section
-- **Missing files**: If audit can't generate, run `npx --yes --package spec-superflow@0.11.0 ssf audit` manually
+- **Missing files**: If audit can't generate, run `npx --yes --package spec-superflow@0.12.0 ssf audit` manually
 - **User interruption**: Re-run verification from the beginning on resume
 - **DP gaps**: Flag missing DPs during DP-6; ask user whether to proceed or return

--- a/skills/spec-merger/SKILL.md
+++ b/skills/spec-merger/SKILL.md
@@ -10,7 +10,7 @@ Before the final `executing → closing` transition, delta specs (ADDED/MODIFIED
 ## Execution-State Guard
 
 Before `ssf sync` or any other write, run
-`npx --yes --package spec-superflow@0.11.0 ssf state get <change-dir> state`.
+`npx --yes --package spec-superflow@0.12.0 ssf state get <change-dir> state`.
 Continue only when the persisted state is exactly `executing`. If it is
 `closing` → STOP: "Closing is terminal. Do not route this change to spec-merger;
 synchronization belongs before the final executing → closing transition." For
@@ -20,7 +20,7 @@ any other state, or if the state cannot be read → STOP and route through
 ## Pre-Flight Checks
 
 ### Conflict Detection
-Run `npx --yes --package spec-superflow@0.11.0 ssf sync <change-dir>`. If conflicts are detected (same requirement modified by multiple changes), present the conflict list to the user for resolution order.
+Run `npx --yes --package spec-superflow@0.12.0 ssf sync <change-dir>`. If conflicts are detected (same requirement modified by multiple changes), present the conflict list to the user for resolution order.
 
 ## Sync Process
 

--- a/skills/spec-writer/SKILL.md
+++ b/skills/spec-writer/SKILL.md
@@ -13,7 +13,7 @@ Read `.spec-superflow.yaml` (especially `dp_0_decisions`, `dp_0_confirmed`) and 
 
 ## Config Check
 
-Run: `npx --yes --package spec-superflow@0.11.0 ssf runtime config --get artifacts.order` — generate in configured order (default: proposal → specs → design → tasks). Run with `artifacts.skip` — skip any listed artifacts.
+Run: `npx --yes --package spec-superflow@0.12.0 ssf runtime config --get artifacts.order` — generate in configured order (default: proposal → specs → design → tasks). Run with `artifacts.skip` — skip any listed artifacts.
 
 ## Artifact Roles
 
@@ -73,8 +73,8 @@ Generate one at a time. Confirm each before next. This prevents scope drift — 
 
 Present summary of all 4 artifacts (2-3 sentences each). Ask user for adjustments. After approval:
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_2_result "approved: <summary>"
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_2_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_2_result "approved: <summary>"
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_2_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 
 ## Handoff Rule

--- a/skills/workflow-start/SKILL.md
+++ b/skills/workflow-start/SKILL.md
@@ -15,7 +15,7 @@ Do NOT invoke for: general coding tasks outside spec-superflow changes, casual q
 
 ## States
 
-`exploring` → `specifying` → `bridging` → `approved-for-build` → `executing` → `closing`, with `debugging` side-path from `executing`, and `abandoned` as terminal. If a transition is ambiguous, run `npx --yes --package spec-superflow@0.11.0 ssf runtime asset read docs/state-machine.md`.
+`exploring` → `specifying` → `bridging` → `approved-for-build` → `executing` → `closing`, with `debugging` side-path from `executing`, and `abandoned` as terminal. If a transition is ambiguous, run `npx --yes --package spec-superflow@0.12.0 ssf runtime asset read docs/state-machine.md`.
 
 ## Terminal-State Short Circuit
 
@@ -27,25 +27,25 @@ scan, or `release-archivist`; do not resume, hand off, or route any more work.
 
 ## Initialization
 
-1. **Update check**: Run `npx --yes --package spec-superflow@0.11.0 ssf runtime check-update`. Exit 0 → continue. Exit 1 → non-blocking upgrade reminder. Exit 2 → skip.
+1. **Update check**: Run `npx --yes --package spec-superflow@0.12.0 ssf runtime check-update`. Exit 0 → continue. Exit 1 → non-blocking upgrade reminder. Exit 2 → skip.
 2. **Inspect change folder**: Check for `proposal.md`, `specs/`, `design.md`, `tasks.md`, `execution-contract.md`. Answer: Is the change fuzzy? Artifacts missing/unstable? Contract exist? User approved contract? Execution in progress or blocked? In verification/wrap-up?
 
 ## Overlay Recovery Scan
 
-3. **Overlay recovery scan**: Run `npx --yes --package spec-superflow@0.11.0 ssf handoff list <change-dir> --json` and `npx --yes --package spec-superflow@0.11.0 ssf checkpoint list <change-dir> --json`. A `result-ready` handoff requires explicit review and `npx --yes --package spec-superflow@0.11.0 ssf handoff resolve` before resuming the affected work. An `active` handoff is non-blocking side work. Show a non-stale checkpoint as recovery context; show a stale checkpoint only as historical evidence.
+3. **Overlay recovery scan**: Run `npx --yes --package spec-superflow@0.12.0 ssf handoff list <change-dir> --json` and `npx --yes --package spec-superflow@0.12.0 ssf checkpoint list <change-dir> --json`. A `result-ready` handoff requires explicit review and `npx --yes --package spec-superflow@0.12.0 ssf handoff resolve` before resuming the affected work. An `active` handoff is non-blocking side work. Show a non-stale checkpoint as recovery context; show a stale checkpoint only as historical evidence.
 
 ## Execution-Control Recovery Scan
 
-4. **Execution-control recovery scan**: For Full or legacy Hotfix in `approved-for-build`, `executing`, or `debugging`, run `npx --yes --package spec-superflow@0.11.0 ssf execution show <change-dir> --json`. Treat only `current: true` plus `waves[].eligible: true` as permission to start a wave. Do not require this scan for Quick, Tweak, or a valid direct Hotfix receipt.
+4. **Execution-control recovery scan**: For Full or legacy Hotfix in `approved-for-build`, `executing`, or `debugging`, run `npx --yes --package spec-superflow@0.12.0 ssf execution show <change-dir> --json`. Treat only `current: true` plus `waves[].eligible: true` as permission to start a wave. Do not require this scan for Quick, Tweak, or a valid direct Hotfix receipt.
 
 ## Direct Short-Path Intake
 
 For a clearly bounded Quick or incident Hotfix request, recommend and accept in the same turn. Do not collect the six intake facts as a questionnaire: infer the available facts from the request and repository, show the single recommendation and qualification reason, then run:
 
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state init <change-dir>
-npx --yes --package spec-superflow@0.11.0 ssf workflow recommend <change-dir> --task-count <n> --file-count <n> --config-doc-only no --schema-api-change no --new-module no --uncertainty low --request-kind <standard|incident>
-npx --yes --package spec-superflow@0.11.0 ssf workflow accept <change-dir> --source direct-request
+npx --yes --package spec-superflow@0.12.0 ssf state init <change-dir>
+npx --yes --package spec-superflow@0.12.0 ssf workflow recommend <change-dir> --task-count <n> --file-count <n> --config-doc-only no --schema-api-change no --new-module no --uncertainty low --request-kind <standard|incident>
+npx --yes --package spec-superflow@0.12.0 ssf workflow accept <change-dir> --source direct-request
 ```
 
 Quick is ≤3 tasks/files of low-risk code. Hotfix is an incident with a reproducible symptom and ≤2 tasks/files. Display `Observed`, `Recommended`, `Why`, and any risk reasons; acceptance is the user's direct request to proceed. Do not create planning artifacts, a contract, an execution plan, wave receipts, or DP approvals. Transition through the receipt-aware guard, execute bounded work, and require `test_result: pass` before closing. A fourth code file, behavioral-constraint change (PRD/spec/design/API/data/permission), cross-module work, a new module, high uncertainty, or failed verification does not auto-escalate: show Quick and Full, then wait for the user's choice. A user selecting Quick must acknowledge the recommendation and choose `tdd`, `new-test`, or `bounded` verification in the receipt. A legacy Hotfix without a valid direct receipt remains on the Full contract/DP-3/plan/review path.
@@ -88,29 +88,29 @@ state or cause a phase transition.
    command. Validate the change name as one non-empty relative path segment
    (not `.` or `..`, with no `/` or `\\`), resolve the change dir as `<project-root>/changes/<change-name>`, and reject any normalized path that
    escapes the project's `changes/` directory.
-2. If the state file is absent or `dp_0_confirmed` is `false`/null, run `npx --yes --package spec-superflow@0.11.0 ssf state init <change-dir>` before `show`; initialization must leave DP-0 unconfirmed.
+2. If the state file is absent or `dp_0_confirmed` is `false`/null, run `npx --yes --package spec-superflow@0.12.0 ssf state init <change-dir>` before `show`; initialization must leave DP-0 unconfirmed.
 3. Read `state.workflow`. An explicit `full` workflow wins and skips automatic
    recommendation. For an explicit `hotfix`/`tweak`/`quick`, report the active
    path; if scope, risk, or verification now exceeds its boundary, refresh the
    recommendation with observed facts and route it to Full instead of continuing.
-4. For `auto`/`null`/unset, run `npx --yes --package spec-superflow@0.11.0 ssf workflow show <change-dir> --json` before collecting or changing any facts. A missing receipt is represented as `needs-input` with all six fixed facts in `missing_facts`.
+4. For `auto`/`null`/unset, run `npx --yes --package spec-superflow@0.12.0 ssf workflow show <change-dir> --json` before collecting or changing any facts. A missing receipt is represented as `needs-input` with all six fixed facts in `missing_facts`.
 5. If the response is `needs-input`, ask only for `missing_facts`; do not ask
    for any fact not listed by the receipt. Do not invent facts from missing
    artifacts and do not default the path to `full`.
-6. Run `npx --yes --package spec-superflow@0.11.0 ssf workflow recommend <change-dir> ...` once with one complete fact snapshot.
+6. Run `npx --yes --package spec-superflow@0.12.0 ssf workflow recommend <change-dir> ...` once with one complete fact snapshot.
 7. Show the user `Observed`, `Available`, `Recommended`, and `Why`. A
    recommendation is advice only: never persist it as the workflow selection.
 8. A recommended low-risk Quick or incident Hotfix is accepted only with
-   `npx --yes --package spec-superflow@0.11.0 ssf workflow accept <change-dir> --source direct-request`.
+   `npx --yes --package spec-superflow@0.12.0 ssf workflow accept <change-dir> --source direct-request`.
    For Full, legacy Hotfix, or Tweak, obtain the user's explicit choice and run
-   `npx --yes --package spec-superflow@0.11.0 ssf workflow select <change-dir> --mode <full|hotfix|tweak> --confirm --reason "<user choice>"`. For a risk-signalled Quick choice, run `workflow select --mode quick --confirm --acknowledge-recommendation --verification <tdd|new-test|bounded>`.
+   `npx --yes --package spec-superflow@0.12.0 ssf workflow select <change-dir> --mode <full|hotfix|tweak> --confirm --reason "<user choice>"`. For a risk-signalled Quick choice, run `workflow select --mode quick --confirm --acknowledge-recommendation --verification <tdd|new-test|bounded>`.
 9. Add `--acknowledge-recommendation` only after the user chooses a
    non-recommended selectable path. Report the persisted receipt and DP-0 audit summary.
 10. To escalate a selected Quick, direct Hotfix, or Tweak, refresh
    `workflow recommend` with observed risk facts, then select `full` with
    `--confirm` (and `--acknowledge-recommendation` only if required). Do not
    overwrite an explicit mode without this persisted recommendation.
-11. Keep `npx --yes --package spec-superflow@0.11.0 ssf runtime infer <change-dir>` only for legacy artifact inference and validation compatibility; it cannot replace user selection at intake.
+11. Keep `npx --yes --package spec-superflow@0.12.0 ssf runtime infer <change-dir>` only for legacy artifact inference and validation compatibility; it cannot replace user selection at intake.
 
 ### Confirm DP-0
 
@@ -124,10 +124,10 @@ and language entries; never replace them with the path summary alone.
 
 After that combined confirmation:
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_0_decisions "<combined summary preserving scope, artifact_language, and workflow_path>"
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_0_result confirmed
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_0_confirmed true
-npx --yes --package spec-superflow@0.11.0 ssf state set <change-dir> dp_0_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_0_decisions "<combined summary preserving scope, artifact_language, and workflow_path>"
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_0_result confirmed
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_0_confirmed true
+npx --yes --package spec-superflow@0.12.0 ssf state set <change-dir> dp_0_timestamp $(date -u +%Y-%m-%dT%H:%M:%SZ)
 ```
 
 Config-aware routing: check `artifacts.order`, `artifacts.skip`, and
@@ -139,19 +139,19 @@ Config-aware routing: check `artifacts.order`, `artifacts.skip`, and
 Change is fuzzy, scope unclear, comparing options, no stable change name.
 
 ### Route to spec-writer (Full only)
-Guard: `npx --yes --package spec-superflow@0.11.0 ssf runtime guard check <dir> exploring specifying --json` → fail = BLOCK. User knows what they want, artifacts missing/incomplete.
+Guard: `npx --yes --package spec-superflow@0.12.0 ssf runtime guard check <dir> exploring specifying --json` → fail = BLOCK. User knows what they want, artifacts missing/incomplete.
 
 ### Route to contract-builder
 Only for Full or legacy Hotfix. Guard: `... check <dir> specifying bridging --json` → fail = BLOCK. Artifacts exist, implementation requested, contract missing/stale. Include `DP-3: 契约批准`.
 
 ### Route to build-executor
-For Full or legacy Hotfix: contract exists and approved, contract matches artifacts. Include `DP-4: 执行模式选择`: propose waves, run `npx --yes --package spec-superflow@0.11.0 ssf execution recommend <change-dir> [--wave ...]`, then run `npx --yes --package spec-superflow@0.11.0 ssf execution plan <change-dir> --mode <selected> --confirm ...` and `execution show`. For Quick, Tweak, or direct Hotfix: use the receipt-aware guard and bounded verification; do not require DP-4, a contract, plan, or review receipt.
+For Full or legacy Hotfix: contract exists and approved, contract matches artifacts. Include `DP-4: 执行模式选择`: propose waves, run `npx --yes --package spec-superflow@0.12.0 ssf execution recommend <change-dir> [--wave ...]`, then run `npx --yes --package spec-superflow@0.12.0 ssf execution plan <change-dir> --mode <selected> --confirm ...` and `execution show`. For Quick, Tweak, or direct Hotfix: use the receipt-aware guard and bounded verification; do not require DP-4, a contract, plan, or review receipt.
 
 ### Route to bug-investigator
 Execution hit blockage: test failure, unexpected behavior, build error, task cannot proceed. After debugging, route back to build-executor.
 
 ### Route to code-reviewer (Full/legacy Hotfix only)
-The current planned wave is implemented and ready for spec-compliance + code-quality verification. A reviewer must write an `npx --yes --package spec-superflow@0.11.0 ssf execution review <change-dir> --wave <id> --base <sha> --head <sha> --report <path> --verdict <pass|fail>` receipt before any dependent wave or closing transition. Quick, Tweak, and direct Hotfix use their verification summary instead.
+The current planned wave is implemented and ready for spec-compliance + code-quality verification. A reviewer must write an `npx --yes --package spec-superflow@0.12.0 ssf execution review <change-dir> --wave <id> --base <sha> --head <sha> --report <path> --verdict <pass|fail>` receipt before any dependent wave or closing transition. Quick, Tweak, and direct Hotfix use their verification summary instead.
 
 ### Route to release-archivist
 Only while the current state is `executing`: implementation is complete and verification is ready. For Full/legacy Hotfix, run the guard and complete verification, audit, delta merge, and DP-7. For Quick, Tweak, and direct Hotfix, run the receipt-aware guard, persist `test_result: pass`, and produce the verification summary without audit or DP-7.
@@ -170,10 +170,10 @@ uncertainty. Do not create a prototype handoff or enter a prototype worktree
 until the user confirms. After confirmation:
 
 ```bash
-npx --yes --package spec-superflow@0.11.0 ssf handoff create <change-dir> \
+npx --yes --package spec-superflow@0.12.0 ssf handoff create <change-dir> \
   --type prototype --objective "<confirmed objective>" \
   --expected-output "<expected evidence>" --acceptance "<completion criterion>"
-npx --yes --package spec-superflow@0.11.0 ssf isolate <change-dir> prototype-<handoff-id>
+npx --yes --package spec-superflow@0.12.0 ssf isolate <change-dir> prototype-<handoff-id>
 ```
 
 Never suggest or enter this route automatically for backend, CLI, configuration,
@@ -184,7 +184,7 @@ work.
 - **Legacy Hotfix**: Route to contract-builder (minimal), skip need-explorer + spec-writer, guard check `exploring bridging --workflow hotfix`, then `bridging -> approved-for-build`, after DP-3 → build-executor (recommend, show, and confirm an execution mode), after → release-archivist (lightweight). It may skip planning artifacts but still requires a minimal contract, DP-3, and a current execution plan. A direct Hotfix instead follows Direct Short-Path Intake.
 - **Tweak**: Route to build-executor (direct edit), skip need-explorer + spec-writer + contract-builder, guard check `exploring approved-for-build --workflow tweak`, after → release-archivist (lightweight)
 
-Post-transition: 💡 `npx --yes --package spec-superflow@0.11.0 ssf inject <change-dir>` to update phase-guard artifacts.
+Post-transition: 💡 `npx --yes --package spec-superflow@0.12.0 ssf inject <change-dir>` to update phase-guard artifacts.
 
 ## Staleness Detection
 
@@ -199,7 +199,7 @@ Use content inspection, not timestamps.
 ## Guardrails
 
 - Full/legacy Hotfix: no implementation before planning artifacts or contract exist
-- No implementation for Full or legacy Hotfix without a current `npx --yes --package spec-superflow@0.11.0 ssf execution plan`; no state transition based on an unverified DP-4 string
+- No implementation for Full or legacy Hotfix without a current `npx --yes --package spec-superflow@0.12.0 ssf execution plan`; no state transition based on an unverified DP-4 string
 - No "continue" without state inspection
 - Full/legacy Hotfix: no implementation past stale contract
 - No implementation past bug without investigation

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -188,14 +188,14 @@ describe('closing terminal lifecycle', () => {
     }
   });
 
-  it('records the #64 terminal closing repair in the dated current release', () => {
+  it('keeps the #64 terminal closing repair in its v0.11.0 release record', () => {
     const changelog = read('CHANGELOG.md');
     const unreleased = section(changelog, '## [Unreleased]');
-    const currentRelease = section(changelog, `## [${VERSION}] - 2026-07-21`);
+    const repairedRelease = section(changelog, '## [0.11.0] - 2026-07-21');
 
     assert.equal(unreleased.trim(), '## [Unreleased]');
-    assert.match(currentRelease, /#64/);
-    assert.match(currentRelease, /closing/i);
-    assert.match(currentRelease, /终态/);
+    assert.match(repairedRelease, /#64/);
+    assert.match(repairedRelease, /closing/i);
+    assert.match(repairedRelease, /终态/);
   });
 });


### PR DESCRIPTION
## Release preparation
- sync all manifests, runtime skill references, and version displays to 0.12.0
- add the v0.12.0 changelog entry
- make the #64 historical release-record test independent from the current package version

## Verification
- npm run build
- npm test
- npm run validate
- node scripts/check-version-consistency.mjs
- node scripts/spec-superflow.mjs doctor
- node scripts/spec-superflow.mjs version 0.12.0 --dry-run
- node --test tests/lib/recovery-command-assets.test.mjs
- npm_config_cache=/private/tmp/spec-superflow-npm-cache npm run test:raw-mode
- WorkBuddy local-install smoke

No tag, GitHub Release, or npm publish has been performed.