### PR TITLE
feat: add install-codebuddy for CodeBuddy Code CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: true
 
   platform-install-smoke:
-    name: Platform Install Smoke (8 platforms)
+    name: Platform Install Smoke (9 platforms)
     runs-on: ubuntu-latest
     if: "!startsWith(github.ref, 'refs/tags/')"
     strategy:
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Smoke test all 8 platform installers (--local)
+      - name: Smoke test all 9 platform installers (--local)
         shell: bash
         run: |
           set -e
@@ -64,7 +64,25 @@ jobs:
             fi
             echo "OK $id — 9 skills, rule=${RULES[$id]:-none}"
           done
-          echo "All 8 platform installers passed smoke test."
+          # CodeBuddy deploys to a user-level config dir via --config-dir (not the
+          # project-level layout used by the 8 installers above). Verify the
+          # settings.json SessionStart contract, the command adapter rewrite, and
+          # the phase-guard alwaysApply:false frontmatter.
+          cb_tmp="$(mktemp -d)"
+          node "$GITHUB_WORKSPACE/scripts/install-codebuddy.mjs" --local "$GITHUB_WORKSPACE" --config-dir "$cb_tmp" > /dev/null
+          [ -d "$cb_tmp/skills" ] || { echo "FAIL codebuddy: skills dir missing"; exit 1; }
+          cb_count="$(ls "$cb_tmp/skills" | wc -l | tr -d ' ')"
+          [ "$cb_count" -ge 9 ] || { echo "FAIL codebuddy: only $cb_count skills (expected 9)"; exit 1; }
+          [ -d "$cb_tmp/commands/ssf" ] || { echo "FAIL codebuddy: commands/ssf missing"; exit 1; }
+          [ -f "$cb_tmp/rules/phase-guard.md" ] || { echo "FAIL codebuddy: phase-guard missing"; exit 1; }
+          [ -f "$cb_tmp/settings.json" ] || { echo "FAIL codebuddy: settings.json missing"; exit 1; }
+          grep -q '"SessionStart"' "$cb_tmp/settings.json" || { echo "FAIL codebuddy: no SessionStart in settings.json"; exit 1; }
+          grep -q 'alwaysApply: false' "$cb_tmp/rules/phase-guard.md" || { echo "FAIL codebuddy: phase-guard frontmatter missing"; exit 1; }
+          ! grep -q 'npx --yes --package spec-superflow@' "$cb_tmp/commands/ssf/resume.md" || { echo "FAIL codebuddy: resume.md still uses npx"; exit 1; }
+          grep -q 'Bash(node:\*)' "$cb_tmp/commands/ssf/resume.md" || { echo "FAIL codebuddy: resume.md allowed-tools not rewritten to node"; exit 1; }
+          rm -rf "$cb_tmp"
+          echo "OK codebuddy — 9 skills, settings.json SessionStart, commands rewritten, phase-guard scoped"
+          echo "All 9 platform installers passed smoke test."
 
   release:
     name: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- **CodeBuddy Code CLI installer**: `ssf install-codebuddy` deploys spec-superflow to `~/.codebuddy/` for CodeBuddy Code CLI. SessionStart hook is written to `~/.codebuddy/settings.json` (CodeBuddy's canonical hook location — the user-level `hooks/hooks.json` is not auto-loaded), recovery command adapters are rewritten to call the deployed local runtime instead of a pinned `npx` package, and `phase-guard.md` uses `alwaysApply:false` frontmatter so ordinary projects are not forced into the workflow. Adds `ssf uninstall-codebuddy` for precise, safe teardown.
+
+### Fixed
+
+- **CodeBuddy install/teardown safety**: `ssf uninstall-codebuddy` precisely removes spec-superflow's own artifacts (SessionStart entries in `settings.json`, runtime dir, commands, phase-guard rule, 9 skills) while preserving other skills, rules, hooks, and settings fields. The previous `rm -f ~/.codebuddy/hooks/hooks.json` advice, which deleted unrelated hooks, is replaced by the dedicated uninstall command. CI `platform-install-smoke` now covers CodeBuddy (settings.json SessionStart, command rewrite, phase-guard frontmatter).
+
 ## [0.12.1] - 2026-07-27
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -433,12 +433,11 @@ ssf install-codebuddy --config-dir /path/to/.codebuddy
 ├── spec-superflow/              ← pluginRoot（运行时依赖；${CLAUDE_PLUGIN_ROOT} 目标）
 │   ├── scripts/  docs/  templates/  dist/  hooks/
 │   │   └── session-start        ← 输出 hookSpecificOutput（CodeBuddy 分支）
-│   ├── commands/ssf/{resume,save,switch}.md
 │   └── package.json
 ├── skills/                      ← 部署的 skill（路径已重写；其他 skill 保留）
 │   ├── workflow-start/
 │   └── ... (9 skills)
-├── commands/ssf/                ← canonical recovery command adapters
+├── commands/ssf/                ← canonical recovery command adapters（共享目录，可含用户自建 command）
 │   ├── resume.md                ← 已重写：node <plugin>/scripts/spec-superflow.mjs（非 npx）
 │   ├── save.md                  ← allowed-tools: Bash(node:*)
 │   └── switch.md

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,7 @@
 | Gemini CLI | `gemini extensions install` | `gemini extensions update` | `gemini extensions uninstall` |
 | OpenCode | plugin entry / skills 目录 | `git pull` | 删除 plugin/skills |
 | WorkBuddy | `ssf install-workbuddy` | 重新运行安装器 | 删除 marketplace 插件并禁用 |
+| CodeBuddy Code CLI | `ssf install-codebuddy` | 重新运行安装器 | 删除 `~/.codebuddy/spec-superflow/` + skills + hooks |
 | Trae IDE / TRAE Work | `.trae/skills` / 上传 zip 或 .skill / marketplace | `git pull` + 重新导入 | UI 卸载或删除技能目录 |
 | Cline | `ssf install-cline` | 重新运行脚本 | 删除 `.cline/skills/`、`.clinerules/` |
 | Kiro | `ssf install-kiro` | 重新运行脚本 | 删除 `.kiro/skills/`、`.kiro/steering/` |
@@ -394,6 +395,87 @@ cat ~/.workbuddy/plugins/marketplaces/cb_teams_marketplace/plugins/spec-superflo
 ```
 
 重启 WorkBuddy 后，在对话中输入「用 workflow-start 开始」即可启动工作流。
+
+---
+
+## CodeBuddy Code CLI
+
+CodeBuddy Code CLI 直接从 `~/.codebuddy/skills/` 读取 skill，hooks 从 `~/.codebuddy/hooks/hooks.json`（Claude Code `SessionStart` 风格）加载。与 WorkBuddy 的 marketplace 插件模型不同，CodeBuddy CLI 把 skill 直接放进共享 `skills/` 目录，与其他 skill 共存；运行时依赖（scripts/docs/templates/dist/hooks）放在独立的 `~/.codebuddy/spec-superflow/` 目录下作为 `${CLAUDE_PLUGIN_ROOT}`。
+
+### 安装（推荐：一键脚本）
+
+```bash
+npx spec-superflow@latest install-codebuddy
+```
+
+本地仓库调试：
+
+```bash
+node /absolute/path/to/spec-superflow/scripts/spec-superflow.mjs install-codebuddy --local /absolute/path/to/spec-superflow
+```
+
+`--dry-run` 预览部署计划：
+
+```bash
+ssf install-codebuddy --dry-run
+```
+
+指定 CodeBuddy 配置目录（默认 `~/.codebuddy`）：
+
+```bash
+ssf install-codebuddy --config-dir /path/to/.codebuddy
+```
+
+### 部署结构
+
+```text
+~/.codebuddy/
+├── spec-superflow/              ← pluginRoot（运行时依赖；${CLAUDE_PLUGIN_ROOT} 目标）
+│   ├── scripts/  docs/  templates/  dist/  hooks/
+│   │   └── session-start
+│   ├── commands/ssf/{resume,save,switch}.md
+│   └── package.json
+├── skills/                      ← 部署的 skill（路径已重写；其他 skill 保留）
+│   ├── workflow-start/
+│   └── ... (9 skills)
+├── commands/ssf/                ← canonical recovery command adapters
+├── rules/
+│   └── phase-guard.md           ← phase-guard 规则（其他 rules 文件不受影响）
+└── hooks/
+    └── hooks.json               ← SessionStart hook 配置
+```
+
+安装器只会清理源仓库中存在的同名 skill 目录——其他 skill 会被保留。`hooks.json` 采用合并策略：保留非 spec-superflow 的 SessionStart 条目和其他事件 hook。
+
+### 升级
+
+重新运行安装命令即可覆盖运行时依赖、刷新 skill、更新 phase-guard 与 hooks：
+
+```bash
+npx spec-superflow@latest install-codebuddy
+```
+
+### 卸载
+
+```bash
+rm -rf ~/.codebuddy/spec-superflow
+rm -rf ~/.codebuddy/commands/ssf
+rm -f ~/.codebuddy/rules/phase-guard.md
+rm -f ~/.codebuddy/hooks/hooks.json   # 若有其他 hook，手动移除 spec-superflow 条目即可
+```
+
+然后逐个删除 `~/.codebuddy/skills/` 下的 9 个 spec-superflow skill 目录（`workflow-start`、`build-executor`、`code-reviewer`、`contract-builder`、`need-explorer`、`release-archivist`、`spec-merger`、`spec-writer`、`bug-investigator`）。
+
+### 验证
+
+```bash
+ls ~/.codebuddy/skills/                                       # 应包含 9 个 spec-superflow skill
+ls ~/.codebuddy/spec-superflow/hooks/session-start            # hook 脚本存在
+cat ~/.codebuddy/hooks/hooks.json                             # SessionStart 指向 spec-superflow/hooks/session-start
+cat ~/.codebuddy/spec-superflow/package.json | grep version   # 期望版本，如 0.12.1
+```
+
+重启 CodeBuddy Code CLI 后，在对话中输入「用 workflow-start 开始」即可启动工作流。
 
 ---
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@
 | Gemini CLI | `gemini extensions install` | `gemini extensions update` | `gemini extensions uninstall` |
 | OpenCode | plugin entry / skills 目录 | `git pull` | 删除 plugin/skills |
 | WorkBuddy | `ssf install-workbuddy` | 重新运行安装器 | 删除 marketplace 插件并禁用 |
-| CodeBuddy Code CLI | `ssf install-codebuddy` | 重新运行安装器 | 删除 `~/.codebuddy/spec-superflow/` + skills + hooks |
+| CodeBuddy Code CLI | `ssf install-codebuddy` | 重新运行安装器 | `ssf uninstall-codebuddy` |
 | Trae IDE / TRAE Work | `.trae/skills` / 上传 zip 或 .skill / marketplace | `git pull` + 重新导入 | UI 卸载或删除技能目录 |
 | Cline | `ssf install-cline` | 重新运行脚本 | 删除 `.cline/skills/`、`.clinerules/` |
 | Kiro | `ssf install-kiro` | 重新运行脚本 | 删除 `.kiro/skills/`、`.kiro/steering/` |
@@ -400,7 +400,7 @@ cat ~/.workbuddy/plugins/marketplaces/cb_teams_marketplace/plugins/spec-superflo
 
 ## CodeBuddy Code CLI
 
-CodeBuddy Code CLI 直接从 `~/.codebuddy/skills/` 读取 skill，hooks 从 `~/.codebuddy/hooks/hooks.json`（Claude Code `SessionStart` 风格）加载。与 WorkBuddy 的 marketplace 插件模型不同，CodeBuddy CLI 把 skill 直接放进共享 `skills/` 目录，与其他 skill 共存；运行时依赖（scripts/docs/templates/dist/hooks）放在独立的 `~/.codebuddy/spec-superflow/` 目录下作为 `${CLAUDE_PLUGIN_ROOT}`。
+CodeBuddy Code CLI 直接从 `~/.codebuddy/skills/` 读取 skill，从 `~/.codebuddy/rules/*.md` 自动加载规则（支持 frontmatter 控制是否总是应用），SessionStart hook 从 `~/.codebuddy/settings.json` 的 `hooks` 字段加载（**不是** `~/.codebuddy/hooks/hooks.json`——CodeBuddy 用户级 `hooks.json` 不会被自动加载）。与 WorkBuddy 的 marketplace 插件模型不同，CodeBuddy CLI 把 skill 直接放进共享 `skills/` 目录，与其他 skill 共存；运行时依赖（scripts/docs/templates/dist/hooks）放在独立的 `~/.codebuddy/spec-superflow/` 目录下作为 `${CLAUDE_PLUGIN_ROOT}`。安装器还会把三个 recovery command adapter 重写为调用已部署的本地 runtime（而非固定版本的 `npx` 包），并把 `phase-guard.md` 设为 `alwaysApply: false` 以避免影响普通项目。
 
 ### 安装（推荐：一键脚本）
 
@@ -432,24 +432,26 @@ ssf install-codebuddy --config-dir /path/to/.codebuddy
 ~/.codebuddy/
 ├── spec-superflow/              ← pluginRoot（运行时依赖；${CLAUDE_PLUGIN_ROOT} 目标）
 │   ├── scripts/  docs/  templates/  dist/  hooks/
-│   │   └── session-start
+│   │   └── session-start        ← 输出 hookSpecificOutput（CodeBuddy 分支）
 │   ├── commands/ssf/{resume,save,switch}.md
 │   └── package.json
 ├── skills/                      ← 部署的 skill（路径已重写；其他 skill 保留）
 │   ├── workflow-start/
 │   └── ... (9 skills)
 ├── commands/ssf/                ← canonical recovery command adapters
+│   ├── resume.md                ← 已重写：node <plugin>/scripts/spec-superflow.mjs（非 npx）
+│   ├── save.md                  ← allowed-tools: Bash(node:*)
+│   └── switch.md
 ├── rules/
-│   └── phase-guard.md           ← phase-guard 规则（其他 rules 文件不受影响）
-└── hooks/
-    └── hooks.json               ← SessionStart hook 配置
+│   └── phase-guard.md           ← alwaysApply:false（其他 rules 不受影响；普通项目不强制走 workflow）
+└── settings.json                ← SessionStart hook 合并到此处（保留其他字段）
 ```
 
-安装器只会清理源仓库中存在的同名 skill 目录——其他 skill 会被保留。`hooks.json` 采用合并策略：保留非 spec-superflow 的 SessionStart 条目和其他事件 hook。
+安装器只会清理源仓库中存在的同名 skill 目录——其他 skill 会被保留。`settings.json` 采用合并策略：只替换引用 spec-superflow 的 `SessionStart` 条目，保留其他事件 hook、`permissions`、`enabledPlugins` 等字段。
 
 ### 升级
 
-重新运行安装命令即可覆盖运行时依赖、刷新 skill、更新 phase-guard 与 hooks：
+重新运行安装命令即可覆盖运行时依赖、刷新 skill、重写 recovery command adapter、合并 `settings.json` 的 SessionStart hook：
 
 ```bash
 npx spec-superflow@latest install-codebuddy
@@ -457,21 +459,34 @@ npx spec-superflow@latest install-codebuddy
 
 ### 卸载
 
+推荐使用专用卸载命令——它会从 `settings.json` 精确移除 spec-superflow 的 `SessionStart` 条目（保留其他 hook 与所有设置字段），并删除运行时目录、commands、phase-guard 规则与 9 个 skill 目录：
+
 ```bash
-rm -rf ~/.codebuddy/spec-superflow
-rm -rf ~/.codebuddy/commands/ssf
-rm -f ~/.codebuddy/rules/phase-guard.md
-rm -f ~/.codebuddy/hooks/hooks.json   # 若有其他 hook，手动移除 spec-superflow 条目即可
+ssf uninstall-codebuddy
 ```
 
-然后逐个删除 `~/.codebuddy/skills/` 下的 9 个 spec-superflow skill 目录（`workflow-start`、`build-executor`、`code-reviewer`、`contract-builder`、`need-explorer`、`release-archivist`、`spec-merger`、`spec-writer`、`bug-investigator`）。
+`--dry-run` 预览卸载计划：
+
+```bash
+ssf uninstall-codebuddy --dry-run
+```
+
+指定 CodeBuddy 配置目录（默认 `~/.codebuddy`）：
+
+```bash
+ssf uninstall-codebuddy --config-dir /path/to/.codebuddy
+```
+
+> 卸载不会删除其他 skill、其他 rules、其他 hook 条目，也不会删除 `settings.json` 本身——只移除 spec-superflow 自己注入的内容。卸载后需重启 CodeBuddy Code CLI（或通过 `/hooks` 菜单审查）以刷新 hook 快照。
 
 ### 验证
 
 ```bash
 ls ~/.codebuddy/skills/                                       # 应包含 9 个 spec-superflow skill
 ls ~/.codebuddy/spec-superflow/hooks/session-start            # hook 脚本存在
-cat ~/.codebuddy/hooks/hooks.json                             # SessionStart 指向 spec-superflow/hooks/session-start
+cat ~/.codebuddy/settings.json | grep -A4 SessionStart        # SessionStart 指向 spec-superflow/hooks/session-start
+grep allowed-tools ~/.codebuddy/commands/ssf/resume.md        # 应为 Bash(node:*)（非 npx）
+head -2 ~/.codebuddy/rules/phase-guard.md                    # frontmatter 应含 alwaysApply: false
 cat ~/.codebuddy/spec-superflow/package.json | grep version   # 期望版本，如 0.12.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ gemini extensions update spec-superflow   # 升级
 | **WorkBuddy** | `npx spec-superflow@latest install-workbuddy` | 已提供安装器 |
 | **Trae IDE / TRAE Work** | `.trae/skills/`、`~/.trae/skills/` 或上传 zip/.skill | 手动/导入 |
 
-> 共支持 18 个平台，完整安装说明见 [INSTALL.md](INSTALL.md)，支持矩阵见 [docs/platform-matrix.md](docs/platform-matrix.md)。
+> 共支持 19 个平台，完整安装说明见 [INSTALL.md](INSTALL.md)，支持矩阵见 [docs/platform-matrix.md](docs/platform-matrix.md)。
 
 ### CLI 工具链
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ gemini extensions install https://github.com/MageByte-Zero/spec-superflow
 gemini extensions update spec-superflow   # 升级
 ```
 
-### 更多平台（Cline / Kiro / Windsurf / Qwen / Amazon Q / Roo Code / Continue / Pi / Qoder / OpenCode / WorkBuddy / Trae）
+### 更多平台（Cline / Kiro / Windsurf / Qwen / Amazon Q / Roo Code / Continue / Pi / Qoder / OpenCode / WorkBuddy / CodeBuddy / Trae）
 
 | 平台 | 安装方式 | 状态 |
 |------|---------|------|
@@ -117,6 +117,7 @@ gemini extensions update spec-superflow   # 升级
 | **Qoder** | `npx spec-superflow@latest install-qoder` | 已提供安装器 |
 | **OpenCode** | `.opencode/plugins/spec-superflow.js` 或 `.agents/skills -> skills/` | 已提供入口 |
 | **WorkBuddy** | `npx spec-superflow@latest install-workbuddy` | 已提供安装器 |
+| **CodeBuddy Code CLI** | `ssf install-codebuddy` | 已提供安装器 |
 | **Trae IDE / TRAE Work** | `.trae/skills/`、`~/.trae/skills/` 或上传 zip/.skill | 手动/导入 |
 
 > 共支持 19 个平台，完整安装说明见 [INSTALL.md](INSTALL.md)，支持矩阵见 [docs/platform-matrix.md](docs/platform-matrix.md)。
@@ -154,6 +155,8 @@ npx spec-superflow list          # 或通过 npx 使用
 | `ssf execution review <dir> ...` | 为一个计划 wave 记录 review receipt |
 | `ssf install-cursor` | 部署到 Cursor `.cursor/` 目录 |
 | `ssf install-workbuddy` | 部署到 WorkBuddy marketplace 插件（含 skills/rules/runtime） |
+| `ssf install-codebuddy` | 部署到 `~/.codebuddy/`（CodeBuddy Code CLI） |
+| `ssf uninstall-codebuddy` | 从 `~/.codebuddy/` 移除 spec-superflow（CodeBuddy Code CLI） |
 | `ssf install-cline` | 部署到 Cline `.cline/` + `.clinerules/` |
 | `ssf install-kiro` | 部署到 Kiro `.kiro/` + `.kiro/steering/` |
 | `ssf install-windsurf` | 部署到 Windsurf `.windsurf/` + `.windsurf/rules/` |

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -95,6 +95,7 @@ gemini extensions update spec-superflow   # upgrade
 |----------|--------|--------|
 | **OpenCode** | `.opencode/plugins/spec-superflow.js` or `.agents/skills -> skills/` | Entry provided |
 | **WorkBuddy** | `npx spec-superflow@latest install-workbuddy` | Installer provided |
+| **CodeBuddy Code CLI** | `ssf install-codebuddy` | Installer provided |
 | **Trae IDE / TRAE Work** | `.trae/skills/`, `~/.trae/skills/`, or zip/.skill upload | Manual/import |
 
 > Full installation guide: [INSTALL.md](../INSTALL.md)
@@ -126,6 +127,8 @@ npm install -g spec-superflow
 | `ssf handoff resolve <dir> <id> --decision <decision>` | Record an explicit handoff decision |
 | `ssf install-cursor` | Deploy to `.cursor/` directory |
 | `ssf install-workbuddy` | Deploy to WorkBuddy marketplace and enable skills |
+| `ssf install-codebuddy` | Deploy to `~/.codebuddy/` (CodeBuddy Code CLI) |
+| `ssf uninstall-codebuddy` | Remove spec-superflow from `~/.codebuddy/` (CodeBuddy Code CLI) |
 
 ### Version
 

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -1,6 +1,6 @@
 # 平台支持矩阵
 
-spec-superflow 共支持 **18 个** AI 编程平台。每个平台按三层接入：
+spec-superflow 共支持 **19 个** AI 编程平台。每个平台按三层接入：
 
 - **Skills** — 9 个 skill 部署到平台技能目录（`${CLAUDE_PLUGIN_ROOT}` 重写为绝对路径）。
 - **Rules** — phase-guard 规则文件部署到平台规则目录，被平台自动加载为常驻上下文（守卫机制）。
@@ -18,16 +18,17 @@ spec-superflow 共支持 **18 个** AI 编程平台。每个平台按三层接�
 | 6 | Gemini CLI | ✅ | `GEMINI.md`（无 rules 目录） | ✅ |
 | 7 | OpenCode | ✅ | `.opencode/` · md | — |
 | 8 | WorkBuddy | ✅ | `marketplace plugin rules/` · md | — |
-| 9 | Trae | ✅ | — | — |
-| 10 | Cline | ✅ | `.clinerules/`（项目根）· md | — |
-| 11 | Kiro | ✅ | `.kiro/steering/` · md | — ¹ |
-| 12 | Windsurf | ✅ | `.windsurf/rules/` · md | — ¹ |
-| 13 | Qwen Code | ✅ | `.qwen/rules/` · md | — ¹ |
-| 14 | Amazon Q Developer | ✅ | `.amazonq/rules/` · md | — ¹ |
-| 15 | Roo Code | ✅ | `.roo/rules/` · md | — |
-| 16 | Continue | ✅ | `.continue/rules/` · md | — |
-| 17 | Pi | ✅ | —（无规则目录） | — |
-| 18 | Qoder | ✅ | `.qoder/rules/` · md | — |
+| 9 | CodeBuddy Code CLI | ✅ | `~/.codebuddy/rules/` · md (`alwaysApply:false`) | ✅ SessionStart (`settings.json`) |
+| 10 | Trae | ✅ | — | — |
+| 11 | Cline | ✅ | `.clinerules/`（项目根）· md | — |
+| 12 | Kiro | ✅ | `.kiro/steering/` · md | — ¹ |
+| 13 | Windsurf | ✅ | `.windsurf/rules/` · md | — ¹ |
+| 14 | Qwen Code | ✅ | `.qwen/rules/` · md | — ¹ |
+| 15 | Amazon Q Developer | ✅ | `.amazonq/rules/` · md | — ¹ |
+| 16 | Roo Code | ✅ | `.roo/rules/` · md | — |
+| 17 | Continue | ✅ | `.continue/rules/` · md | — |
+| 18 | Pi | ✅ | —（无规则目录） | — |
+| 19 | Qoder | ✅ | `.qoder/rules/` · md | — |
 
 > ¹ Kiro / Windsurf / Qwen / Amazon Q 平台原生支持 hooks（comet 源码确认 hookFormat 分别为 kiro / windsurf / qwen / claude-code），但 spec-superflow 的 SessionStart 钩子在这些平台的可用性尚未逐一验证，故 v0.8.13 暂不写入 hook 配置，避免塞入失效配置。上下文注入由 phase-guard 规则（平台自动加载）承担。后续版本将逐平台验证后补齐。
 
@@ -39,7 +40,7 @@ spec-superflow 共支持 **18 个** AI 编程平台。每个平台按三层接�
 
 ```bash
 npx spec-superflow@latest install-<id>
-# <id> ∈ {cline, kiro, windsurf, qwen, amazon-q, roocode, continue, pi, qoder, cursor, workbuddy}
+# <id> ∈ {cline, kiro, windsurf, qwen, amazon-q, roocode, continue, pi, qoder, cursor, workbuddy, codebuddy}
 ```
 
 Claude Code / Codex / Copilot / Gemini / OpenCode / Trae 走各自 marketplace 或本地目录，详见 [INSTALL.md](../INSTALL.md)。

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -79,6 +79,26 @@ For each example in `docs/examples/`:
   node --input-type=module -e 'import { readFileSync } from "node:fs"; const settings = JSON.parse(readFileSync(process.argv[1], "utf8")); if (settings.enabledPlugins?.["spec-superflow@cb_teams_marketplace"] !== true) throw new Error("WorkBuddy plugin is not enabled");' "$SSF_WORKBUDDY_SMOKE_HOME/.workbuddy/settings.json"
   node --test tests/lib/cmd-install-workbuddy.test.mjs
   ```
+- Run `install-codebuddy` against a temporary config dir and verify the `settings.json` SessionStart contract, command rewrite, phase-guard frontmatter, and safe uninstall.
+
+  ```bash
+  # Local release-candidate smoke for CodeBuddy (never writes ~/.codebuddy).
+  SSF_CODEBUDDY_SMOKE_HOME="$(mktemp -d)"
+  node scripts/spec-superflow.mjs install-codebuddy --local "$PWD" --config-dir "$SSF_CODEBUDDY_SMOKE_HOME"
+  test -f "$SSF_CODEBUDDY_SMOKE_HOME/settings.json"
+  grep -q '"SessionStart"' "$SSF_CODEBUDDY_SMOKE_HOME/settings.json"
+  grep -q 'alwaysApply: false' "$SSF_CODEBUDDY_SMOKE_HOME/rules/phase-guard.md"
+  ! grep -q 'npx --yes --package spec-superflow@' "$SSF_CODEBUDDY_SMOKE_HOME/commands/ssf/resume.md"
+  grep -q 'Bash(node:\*)' "$SSF_CODEBUDDY_SMOKE_HOME/commands/ssf/resume.md"
+  test "$(find "$SSF_CODEBUDDY_SMOKE_HOME/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" = 9
+  # Uninstall must preserve unrelated skills/settings.
+  mkdir -p "$SSF_CODEBUDDY_SMOKE_HOME/skills/other-skill"
+  printf -- '---\nname: other-skill\n---\n' > "$SSF_CODEBUDDY_SMOKE_HOME/skills/other-skill/SKILL.md"
+  node scripts/spec-superflow.mjs uninstall-codebuddy --config-dir "$SSF_CODEBUDDY_SMOKE_HOME"
+  test -d "$SSF_CODEBUDDY_SMOKE_HOME/skills/other-skill"
+  test ! -d "$SSF_CODEBUDDY_SMOKE_HOME/spec-superflow"
+  node --test tests/lib/cmd-install-codebuddy.test.mjs
+  ```
 - `npm run test:raw-mode` — packs the current source and runs a canonical runtime in an empty directory with no plugin-root variables or global `ssf`.
 - Run a representative local-installer smoke test.
 - `spec-superflow.config.json` absence still works (backward compatible defaults)

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -2,9 +2,15 @@
 # v0.12.1: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
-# Three platforms share the same message, only output format differs.
+# Four platforms share the same message, only output format differs.
+# CodeBuddy Code CLI (detected via CODEBUDDY_PROJECT_DIR) loads hooks from
+# ~/.codebuddy/settings.json and requires hookSpecificOutput for SessionStart;
+# Claude Code uses the same shape. Cursor and the generic fallback use the
+# top-level additional_context / additionalContext form.
 if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
   printf '{\n  "additional_context": "%s"\n}\n' "$msg"
+elif [ -n "${CODEBUDDY_PROJECT_DIR:-}" ]; then
+  printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$msg"
 elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
   printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$msg"
 else

--- a/scripts/install-codebuddy.mjs
+++ b/scripts/install-codebuddy.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// scripts/install-codebuddy.mjs — standalone entry for `ssf install-codebuddy`.
+//
+// Deploys spec-superflow to ~/.codebuddy/ for
+// CodeBuddy Code CLI. Run with no args to install the latest GitHub release,
+// or --local <path> to deploy from a local clone.
+//
+// Usage:
+//   node scripts/install-codebuddy.mjs                  # latest GitHub release
+//   node scripts/install-codebuddy.mjs --local /path    # local clone
+//   node scripts/install-codebuddy.mjs --tag v0.12.1    # specific tag
+//   node scripts/install-codebuddy.mjs --dry-run        # preview only
+//   node scripts/install-codebuddy.mjs --config-dir D:/.codebuddy
+import { run } from './lib/cmd-install-codebuddy.mjs';
+
+run(process.argv.slice(2)).catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/cmd-install-codebuddy.mjs
+++ b/scripts/lib/cmd-install-codebuddy.mjs
@@ -1,11 +1,13 @@
 // ssf install-codebuddy — deploy spec-superflow for CodeBuddy Code CLI.
 //
 // CodeBuddy Code CLI reads skills directly from ~/.codebuddy/skills/, rules
-// from ~/.codebuddy/rules/, and session hooks from ~/.codebuddy/hooks/hooks.json
-// (Claude Code SessionStart style). Unlike WorkBuddy, CodeBuddy CLI does NOT use
-// the marketplace plugin model — skills are placed directly in the shared skills/
-// directory and coexist with unrelated skills. Runtime dependencies live under a
-// dedicated spec-superflow/ directory that serves as ${CLAUDE_PLUGIN_ROOT}.
+// from ~/.codebuddy/rules/ (auto-loaded, but frontmatter controls application),
+// and session hooks from ~/.codebuddy/settings.json (the hooks field, NOT
+// ~/.codebuddy/hooks/hooks.json — the user-level hooks.json file is not
+// auto-loaded by CodeBuddy). Unlike WorkBuddy, CodeBuddy CLI does NOT use the
+// marketplace plugin model — skills are placed directly in the shared skills/
+// directory and coexist with unrelated skills. Runtime dependencies live under
+// a dedicated spec-superflow/ directory that serves as ${CLAUDE_PLUGIN_ROOT}.
 //
 // Deploy layout:
 //   ~/.codebuddy/
@@ -18,17 +20,16 @@
 //   │   ├── workflow-start/
 //   │   └── ... (9 skills)
 //   ├── commands/ssf/                ← canonical recovery command adapters
-//   │   ├── resume.md
-//   │   ├── save.md
+//   │   ├── resume.md                (npx→node <pluginRoot>/scripts/spec-superflow.mjs rewritten)
+//   │   ├── save.md                  (allowed-tools: Bash(node:*))
 //   │   └── switch.md
 //   ├── rules/
-//   │   └── phase-guard.md           ← phase-guard rule (other rules preserved)
-//   └── hooks/
-//       └── hooks.json               ← SessionStart hook config
+//   │   └── phase-guard.md           ← phase-guard rule (alwaysApply:false; other rules preserved)
+//   └── settings.json                ← SessionStart hook merged here (preserves other fields)
 //
 // Re-running the installer upgrades in place: it replaces the spec-superflow/
-// runtime dir, refreshes only the source-named skill directories, and
-// overwrites phase-guard.md + hooks.json.
+// runtime dir, refreshes only the source-named skill directories, rewrites the
+// recovery command adapters, and merges SessionStart into settings.json.
 
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { cp, writeFile, mkdtemp } from 'node:fs/promises';
@@ -171,11 +172,26 @@ function assertCanonicalCommands(commandNames) {
   }
 }
 
-async function copyValidatedCommands(commandAssets, targetCommands) {
+async function copyValidatedCommands(commandAssets, targetCommands, pluginRootAbs) {
+  const scriptPath = join(pluginRootAbs, 'scripts', 'spec-superflow.mjs');
+  const nodeCmd = `node ${shellQuote(scriptPath)}`;
   for (const asset of commandAssets) {
     const targetPath = join(targetCommands, ...asset.relativePath.split('/'));
     ensureDir(dirname(targetPath));
-    await writeFile(targetPath, asset.content, 'utf-8');
+    let content = asset.content;
+    // Rewrite npx invocations to call the deployed local runtime instead of a
+    // pinned npm package, so --local installs do not depend on npx fetching a
+    // fixed version at runtime.
+    content = content.replace(
+      /npx --yes --package spec-superflow@\d+\.\d+\.\d+ ssf/g,
+      nodeCmd,
+    );
+    // The command adapters no longer shell out to npx; allow node instead.
+    content = content.replace(
+      /^allowed-tools:\s*Bash\(npx:\*\)\s*$/m,
+      'allowed-tools: Bash(node:*)',
+    );
+    await writeFile(targetPath, content, 'utf-8');
   }
   return commandAssets.length;
 }
@@ -250,7 +266,13 @@ async function copySkillsWithRoot(sourceSkills, targetSkills, pluginRootAbs, sou
 
 /** Phase-guard rule content for CodeBuddy CLI (md format). */
 function phaseGuardContent() {
-  return `# Phase Guard — spec-superflow (codebuddy)
+  return `---
+alwaysApply: false
+---
+
+# Phase Guard — spec-superflow (codebuddy)
+
+> 仅在检测到 spec-superflow 变更工件（\`.spec-superflow.yaml\`、\`proposal.md\`、\`execution-contract.md\`、\`specs/\`）时应用此规则。普通项目无需走 workflow-start，CodeBuddy 不会强制加载本规则（\`alwaysApply: false\`）。
 
 ## 入口规则
 
@@ -282,65 +304,64 @@ function phaseGuardContent() {
 }
 
 /**
- * Build hooks.json content for CodeBuddy CLI (Claude Code SessionStart style).
- * The session-start script path points into the deployed spec-superflow runtime
- * directory so the hook stays valid across upgrades.
+ * Build the SessionStart hook command for CodeBuddy Code CLI.
+ *
+ * CodeBuddy loads hooks from ~/.codebuddy/settings.json (NOT hooks.json — the
+ * user-level hooks.json file is not auto-loaded). The session-start script
+ * path points into the deployed spec-superflow runtime directory so the hook
+ * stays valid across upgrades. Windows forces Git Bash for hook execution,
+ * so double-quoted forward-slash paths work cross-platform.
  */
-function buildHooksJson(sessionStartScript) {
-  // Use double quotes + forward slashes so the command works under both POSIX
-  // shells and Windows cmd.exe (CodeBuddy CLI's hook executor may use either).
-  // shellQuote's POSIX single quotes are not recognized by cmd.exe on Windows.
+function buildSessionStartCommand(sessionStartScript) {
   const normalized = String(sessionStartScript).replace(/\\/g, '/');
-  const command = `bash "${normalized}"`;
+  return `bash "${normalized}"`;
+}
+
+/**
+ * Build the hooks object to merge into ~/.codebuddy/settings.json.
+ */
+function buildSettingsHooks(sessionStartScript) {
   return {
-    description: 'spec-superflow session start hook - injects workflow-start as session context',
-    hooks: {
-      SessionStart: [
-        {
-          hooks: [
-            { type: 'command', command },
-          ],
-        },
-      ],
-    },
+    SessionStart: [
+      {
+        hooks: [{ type: 'command', command: buildSessionStartCommand(sessionStartScript) }],
+      },
+    ],
   };
 }
 
 /**
- * Merge the new spec-superflow SessionStart hook into an existing hooks.json.
+ * Merge the spec-superflow SessionStart hook into ~/.codebuddy/settings.json.
  * Preserves other event types (PreToolUse, PostToolUse, ...) and any
- * SessionStart hook entries that do not reference spec-superflow.
+ * SessionStart hook entries that do not reference spec-superflow, plus all
+ * non-hook top-level fields (permissions, enabledPlugins, ...).
  */
-function mergeHooksJson(existingPath, newConfig) {
+function mergeSettingsJson(existingPath, newHooks) {
   const existing = readJsonIfExists(existingPath);
-  if (!existing || typeof existing !== 'object' || !existing.hooks) {
-    return newConfig;
+  if (!existing || typeof existing !== 'object' || Array.isArray(existing)) {
+    return { hooks: newHooks };
   }
-  const merged = JSON.parse(JSON.stringify(newConfig));
+  const merged = { ...existing };
+  const existingHooks = existing.hooks && typeof existing.hooks === 'object' && !Array.isArray(existing.hooks)
+    ? { ...existing.hooks }
+    : {};
+  merged.hooks = existingHooks;
 
-  for (const event of Object.keys(existing.hooks)) {
-    if (event === 'SessionStart') continue;
-    if (!merged.hooks[event]) merged.hooks[event] = existing.hooks[event];
-  }
+  // Other event types are already preserved via the shallow copy above.
 
-  const preservedSessionEntries = [];
-  for (const entry of existing.hooks.SessionStart || []) {
+  // SessionStart: keep non-spec-superflow entries, replace ssf entry.
+  const preservedEntries = [];
+  for (const entry of existingHooks.SessionStart || []) {
     if (!entry || !Array.isArray(entry.hooks)) continue;
     const nonSsf = entry.hooks.filter(
       h => !h || typeof h !== 'object' || !h.command || !h.command.includes('spec-superflow'),
     );
     if (nonSsf.length) {
-      preservedSessionEntries.push({ hooks: nonSsf });
+      preservedEntries.push({ ...entry, hooks: nonSsf });
     }
   }
-  // New ssf entry first, then preserved non-ssf entries.
-  merged.hooks.SessionStart = [...newConfig.hooks.SessionStart, ...preservedSessionEntries];
+  merged.hooks.SessionStart = [...newHooks.SessionStart, ...preservedEntries];
 
-  // Preserve top-level non-hook fields (e.g. description overrides, metadata).
-  for (const key of Object.keys(existing)) {
-    if (key === 'hooks') continue;
-    if (!(key in merged)) merged[key] = existing[key];
-  }
   return merged;
 }
 
@@ -390,7 +411,7 @@ function planInstall({ pluginRoot = defaultPluginRoot, configDir } = {}) {
   const targetCommands = join(codebuddyRoot, 'commands');
   const targetRules = join(codebuddyRoot, 'rules');
   const targetHooks = join(codebuddyRoot, 'hooks');
-  const hooksJsonPath = join(targetHooks, 'hooks.json');
+  const settingsPath = join(codebuddyRoot, 'settings.json');
   const version = readVersion(root);
   const pluginRootAbs = resolve(targetPluginDir);
   const sessionStartScript = join(pluginRootAbs, 'hooks', 'session-start');
@@ -408,7 +429,7 @@ function planInstall({ pluginRoot = defaultPluginRoot, configDir } = {}) {
     targetCommands,
     targetRules,
     targetHooks,
-    hooksJsonPath,
+    settingsPath,
     version,
     pluginRootAbs,
     sessionStartScript,
@@ -429,7 +450,7 @@ async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = 
     targetCommands,
     targetRules,
     targetHooks,
-    hooksJsonPath,
+    settingsPath,
     version,
     pluginRootAbs,
     sessionStartScript,
@@ -461,8 +482,11 @@ async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = 
   }
 
   // 2. Copy canonical recovery commands as complete Markdown assets.
-  const commandCount = await copyValidatedCommands(commandAssets, targetCommands);
-  console.log(`   commands/ → ${targetCommands} (${commandCount} files, ${commandNames.length} commands)`);
+  //    Rewrite npx → node <local runtime> so --local installs do not pin a
+  //    fixed npm package version (P1: --local recovery commands must use the
+  //    deployed runtime).
+  const commandCount = await copyValidatedCommands(commandAssets, targetCommands, pluginRootAbs);
+  console.log(`   commands/ → ${targetCommands} (${commandCount} files, ${commandNames.length} commands, npx→node rewritten)`);
 
   // 3. Copy skills with ${CLAUDE_PLUGIN_ROOT} rewriting (preserves unrelated skills).
   const count = await copySkillsWithRoot(installPlan.skillsDir, targetSkills, pluginRootAbs, skillNames);
@@ -473,12 +497,15 @@ async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = 
   await writeFile(join(targetRules, 'phase-guard.md'), phaseGuardContent(), 'utf-8');
   console.log(`   phase-guard → ${join(targetRules, 'phase-guard.md')}`);
 
-  // 5. Write/merge hooks.json (SessionStart hook).
-  ensureDir(targetHooks);
-  const hooksConfig = buildHooksJson(sessionStartScript);
-  const mergedHooks = mergeHooksJson(hooksJsonPath, hooksConfig);
-  await writeFile(hooksJsonPath, JSON.stringify(mergedHooks, null, 2) + '\n', 'utf-8');
-  console.log(`   hooks.json → ${hooksJsonPath}`);
+  // 5. Write/merge SessionStart hook into ~/.codebuddy/settings.json.
+  //    CodeBuddy loads hooks from settings.json; user-level hooks.json is not
+  //    auto-loaded, so we target settings.json and merge to preserve other
+  //    fields (permissions, enabledPlugins, other event hooks, ...).
+  ensureDir(codebuddyRoot);
+  const settingsHooks = buildSettingsHooks(sessionStartScript);
+  const mergedSettings = mergeSettingsJson(settingsPath, settingsHooks);
+  await writeFile(settingsPath, JSON.stringify(mergedSettings, null, 2) + '\n', 'utf-8');
+  console.log(`   settings.json → ${settingsPath} (SessionStart hook merged)`);
 
   return installPlan;
 }
@@ -511,7 +538,7 @@ export async function run(args) {
     console.log(`  Skills dir:  ${plan.targetSkills}`);
     console.log(`  Rules:       ${plan.targetRules}/phase-guard.md`);
     console.log(`  Commands:    ${plan.targetCommands}`);
-    console.log(`  Hooks:       ${plan.hooksJsonPath}`);
+    console.log(`  Settings:    ${plan.settingsPath} (SessionStart hook, merged)`);
     return;
   }
 
@@ -544,7 +571,7 @@ export async function run(args) {
     console.log(`   Plugin root: ${plan.targetPluginDir}`);
     console.log(`   Skills dir:  ${plan.targetSkills}`);
     console.log(`   Rules:       ${plan.targetRules}/phase-guard.md`);
-    console.log(`   Hooks:       ${plan.hooksJsonPath}`);
+    console.log(`   Settings:    ${plan.settingsPath} (SessionStart hook merged)`);
     if (installedTag) {
       console.log(`   Version:     ${installedTag}`);
     }

--- a/scripts/lib/cmd-install-codebuddy.mjs
+++ b/scripts/lib/cmd-install-codebuddy.mjs
@@ -1,0 +1,559 @@
+// ssf install-codebuddy — deploy spec-superflow for CodeBuddy Code CLI.
+//
+// CodeBuddy Code CLI reads skills directly from ~/.codebuddy/skills/, rules
+// from ~/.codebuddy/rules/, and session hooks from ~/.codebuddy/hooks/hooks.json
+// (Claude Code SessionStart style). Unlike WorkBuddy, CodeBuddy CLI does NOT use
+// the marketplace plugin model — skills are placed directly in the shared skills/
+// directory and coexist with unrelated skills. Runtime dependencies live under a
+// dedicated spec-superflow/ directory that serves as ${CLAUDE_PLUGIN_ROOT}.
+//
+// Deploy layout:
+//   ~/.codebuddy/
+//   ├── spec-superflow/              ← pluginRoot (runtime deps; ${CLAUDE_PLUGIN_ROOT} target)
+//   │   ├── scripts/  docs/  templates/  dist/  hooks/
+//   │   │   └── session-start
+//   │   ├── commands/ssf/{resume,save,switch}.md
+//   │   └── package.json
+//   ├── skills/                      ← deployed skills (paths rewritten; other skills preserved)
+//   │   ├── workflow-start/
+//   │   └── ... (9 skills)
+//   ├── commands/ssf/                ← canonical recovery command adapters
+//   │   ├── resume.md
+//   │   ├── save.md
+//   │   └── switch.md
+//   ├── rules/
+//   │   └── phase-guard.md           ← phase-guard rule (other rules preserved)
+//   └── hooks/
+//       └── hooks.json               ← SessionStart hook config
+//
+// Re-running the installer upgrades in place: it replaces the spec-superflow/
+// runtime dir, refreshes only the source-named skill directories, and
+// overwrites phase-guard.md + hooks.json.
+
+import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { cp, writeFile, mkdtemp } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { shellQuote } from './shell-quote.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultPluginRoot = resolve(__dirname, '..', '..'); // repo root when run from clone
+
+const PLUGIN_NAME = 'spec-superflow';
+const GITHUB_REPO = 'MageByte-Zero/spec-superflow';
+const GITHUB_API_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+const RUNTIME_DIRS = ['scripts', 'docs', 'templates', 'dist', 'hooks'];
+const CANONICAL_COMMAND_NAMES = ['ssf:resume', 'ssf:save', 'ssf:switch'];
+const CANONICAL_COMMAND_FILES = ['resume.md', 'save.md', 'switch.md'];
+
+// ─── helpers ──────────────────────────────────────────────
+
+function ensureDir(dir) {
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+}
+
+function readJsonIfExists(filePath) {
+  if (!existsSync(filePath)) return {};
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+/**
+ * Resolve the CodeBuddy config root. Defaults to ~/.codebuddy; override with
+ * the --config-dir option when the CLI uses a non-standard data directory.
+ */
+function getCodebuddyRoot(configDir) {
+  if (configDir) return resolve(configDir);
+  return join(homedir(), '.codebuddy');
+}
+
+function listSkillNames(skillsDir) {
+  if (!existsSync(skillsDir)) {
+    throw new Error(`skills/ directory not found at ${skillsDir}`);
+  }
+  return readdirSync(skillsDir)
+    .filter(name => {
+      const dir = join(skillsDir, name);
+      return statSync(dir).isDirectory() && existsSync(join(dir, 'SKILL.md'));
+    })
+    .sort();
+}
+
+function canonicalCommandTreeError(path) {
+  return new Error(
+    `canonical command tree must be exactly commands/ssf/{${CANONICAL_COMMAND_FILES.join(', ')}}: ${path}`,
+  );
+}
+
+function listExactEntries(dir, expectedEntries) {
+  const entries = readdirSync(dir).sort();
+  for (const entry of entries) {
+    const entryPath = join(dir, entry);
+    if (lstatSync(entryPath).isSymbolicLink()) {
+      throw new Error(`symbolic links are not allowed in command source: ${entryPath}`);
+    }
+  }
+  if (
+    entries.length !== expectedEntries.length
+    || entries.some((entry, index) => entry !== expectedEntries[index])
+  ) {
+    throw canonicalCommandTreeError(dir);
+  }
+  return entries;
+}
+
+function listCommandNames(commandsDir) {
+  let commandsStat;
+  try {
+    commandsStat = lstatSync(commandsDir);
+  } catch {
+    throw new Error(`commands/ directory not found at ${commandsDir}`);
+  }
+  if (commandsStat.isSymbolicLink()) {
+    throw new Error(`symbolic links are not allowed in command source: ${commandsDir}`);
+  }
+  if (!commandsStat.isDirectory()) {
+    throw new Error(`commands/ directory not found at ${commandsDir}`);
+  }
+  listExactEntries(commandsDir, ['ssf']);
+
+  const ssfCommandsDir = join(commandsDir, 'ssf');
+  const ssfCommandsStat = lstatSync(ssfCommandsDir);
+  if (ssfCommandsStat.isSymbolicLink()) {
+    throw new Error(`symbolic links are not allowed in command source: ${ssfCommandsDir}`);
+  }
+  if (!ssfCommandsStat.isDirectory()) {
+    throw canonicalCommandTreeError(ssfCommandsDir);
+  }
+  listExactEntries(ssfCommandsDir, CANONICAL_COMMAND_FILES);
+  for (const file of CANONICAL_COMMAND_FILES) {
+    const filePath = join(ssfCommandsDir, file);
+    const fileStat = lstatSync(filePath);
+    if (fileStat.isSymbolicLink()) {
+      throw new Error(`symbolic links are not allowed in command source: ${filePath}`);
+    }
+    if (!fileStat.isFile()) {
+      throw canonicalCommandTreeError(filePath);
+    }
+  }
+  return [...CANONICAL_COMMAND_NAMES];
+}
+
+function snapshotCommandAssets(commandsDir) {
+  listCommandNames(commandsDir);
+  const ssfCommandsDir = join(commandsDir, 'ssf');
+  return Object.freeze(CANONICAL_COMMAND_FILES.map(file => {
+    const filePath = join(ssfCommandsDir, file);
+    const fileStat = lstatSync(filePath);
+    if (fileStat.isSymbolicLink()) {
+      throw new Error(`symbolic links are not allowed in command source: ${filePath}`);
+    }
+    if (!fileStat.isFile()) {
+      throw canonicalCommandTreeError(filePath);
+    }
+    return Object.freeze({
+      relativePath: `ssf/${file}`,
+      content: readFileSync(filePath, 'utf-8'),
+    });
+  }));
+}
+
+function assertCanonicalCommands(commandNames) {
+  if (
+    commandNames.length !== CANONICAL_COMMAND_NAMES.length
+    || commandNames.some((name, index) => name !== CANONICAL_COMMAND_NAMES[index])
+  ) {
+    throw new Error(
+      `canonical recovery command set is required: ${CANONICAL_COMMAND_NAMES.join(', ')}; found: ${commandNames.join(', ') || '(none)'}`,
+    );
+  }
+}
+
+async function copyValidatedCommands(commandAssets, targetCommands) {
+  for (const asset of commandAssets) {
+    const targetPath = join(targetCommands, ...asset.relativePath.split('/'));
+    ensureDir(dirname(targetPath));
+    await writeFile(targetPath, asset.content, 'utf-8');
+  }
+  return commandAssets.length;
+}
+
+/** Recursively copy a directory. Returns the file count. */
+async function copyDir(src, dst, { rejectSymlinks = false } = {}) {
+  if (!existsSync(src)) return 0;
+  ensureDir(dst);
+  const entries = readdirSync(src);
+  let fileCount = 0;
+  for (const name of entries) {
+    const srcPath = join(src, name);
+    const dstPath = join(dst, name);
+    const sourceStat = lstatSync(srcPath);
+    if (sourceStat.isSymbolicLink() && rejectSymlinks) {
+      throw new Error(`symbolic links are not allowed in command source: ${srcPath}`);
+    }
+    const st = sourceStat.isSymbolicLink() ? statSync(srcPath) : sourceStat;
+    if (st.isDirectory()) {
+      fileCount += await copyDir(srcPath, dstPath, { rejectSymlinks });
+    } else {
+      await cp(srcPath, dstPath, { force: true });
+      fileCount += 1;
+    }
+  }
+  return fileCount;
+}
+
+/**
+ * Copy source skills into the shared ~/.codebuddy/skills/ directory, rewriting
+ * ${CLAUDE_PLUGIN_ROOT} to the absolute plugin root. Only skill directories
+ * whose names appear in sourceSkillNames are removed before copying — other
+ * skills in the shared directory are preserved.
+ */
+async function copySkillsWithRoot(sourceSkills, targetSkills, pluginRootAbs, sourceSkillNames) {
+  // Clean only the source-named skill directories (preserve unrelated skills).
+  if (existsSync(targetSkills)) {
+    for (const name of sourceSkillNames) {
+      const dir = join(targetSkills, name);
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  }
+  ensureDir(targetSkills);
+
+  function rewriteRoot(filePath) {
+    if (!existsSync(filePath)) return;
+    let content = readFileSync(filePath, 'utf-8');
+    if (content.includes('${CLAUDE_PLUGIN_ROOT}')) {
+      content = content.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRootAbs);
+    }
+    content = content.replace(
+      /npx --yes --package spec-superflow@\d+\.\d+\.\d+ ssf/g,
+      `node ${shellQuote(join(pluginRootAbs, 'scripts', 'spec-superflow.mjs'))}`,
+    );
+    writeFileSync(filePath, content, 'utf-8');
+  }
+
+  for (const name of sourceSkillNames) {
+    const src = join(sourceSkills, name);
+    const dst = join(targetSkills, name);
+    await cp(src, dst, { recursive: true, force: true });
+    rewriteRoot(join(dst, 'SKILL.md'));
+    // Also fix sub-prompt / reference markdown files in the skill dir.
+    for (const sub of readdirSync(dst).filter(f => f.endsWith('.md') && f !== 'SKILL.md')) {
+      rewriteRoot(join(dst, sub));
+    }
+  }
+  return sourceSkillNames.length;
+}
+
+/** Phase-guard rule content for CodeBuddy CLI (md format). */
+function phaseGuardContent() {
+  return `# Phase Guard — spec-superflow (codebuddy)
+
+## 入口规则
+
+- 所有工作必须从 "/workflow-start" 入口开始。
+- 在 .spec-superflow.yaml 中确认当前 state 和 workflow 模式之前，不要开始写代码。
+
+## 全局禁止
+
+- Full 或 legacy Hotfix 没有 execution-contract.md 或未经用户明确批准，不得进入实现。
+- Full 或 legacy Hotfix 必须先运行 ssf execution plan <change-dir> ...；没有 current execution plan 不得开始实现。
+- 只有 Full/legacy Hotfix 的 all pass review receipts 后才可 closing；不得把未审查的 wave 当作完成。
+- Quick、direct Hotfix、tweak 不要求 contract、execution plan、review receipt 或 DP-3/DP-4；它们须在边界内验证并持久化 test_result: pass。direct Hotfix 必须验证原症状回归。
+- 执行过程中如果发现需求/范围变化，必须回退到 specifying 或 bridging，而不是直接改代码。
+- 不要直接调用执行类 skill（如 "/build-executor"），必须通过入口路由。
+
+## 决策点协议
+
+- DP-0：设计前确认
+- DP-1：需求确认
+- DP-2：工件审查
+- DP-3/DP-4：仅 Full 或 legacy Hotfix 需要 contract 批准与执行模式确认。
+- DP-5：调试升级
+- DP-6：验证失败
+- DP-7：是否收口归档？
+
+> 本文件由 spec-superflow 安装脚本生成（platform: codebuddy）；
+> 对具体变更的 guard 内容请运行 \`ssf inject <change-dir>\` 更新。
+`;
+}
+
+/**
+ * Build hooks.json content for CodeBuddy CLI (Claude Code SessionStart style).
+ * The session-start script path points into the deployed spec-superflow runtime
+ * directory so the hook stays valid across upgrades.
+ */
+function buildHooksJson(sessionStartScript) {
+  // Use double quotes + forward slashes so the command works under both POSIX
+  // shells and Windows cmd.exe (CodeBuddy CLI's hook executor may use either).
+  // shellQuote's POSIX single quotes are not recognized by cmd.exe on Windows.
+  const normalized = String(sessionStartScript).replace(/\\/g, '/');
+  const command = `bash "${normalized}"`;
+  return {
+    description: 'spec-superflow session start hook - injects workflow-start as session context',
+    hooks: {
+      SessionStart: [
+        {
+          hooks: [
+            { type: 'command', command },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Merge the new spec-superflow SessionStart hook into an existing hooks.json.
+ * Preserves other event types (PreToolUse, PostToolUse, ...) and any
+ * SessionStart hook entries that do not reference spec-superflow.
+ */
+function mergeHooksJson(existingPath, newConfig) {
+  const existing = readJsonIfExists(existingPath);
+  if (!existing || typeof existing !== 'object' || !existing.hooks) {
+    return newConfig;
+  }
+  const merged = JSON.parse(JSON.stringify(newConfig));
+
+  for (const event of Object.keys(existing.hooks)) {
+    if (event === 'SessionStart') continue;
+    if (!merged.hooks[event]) merged.hooks[event] = existing.hooks[event];
+  }
+
+  const preservedSessionEntries = [];
+  for (const entry of existing.hooks.SessionStart || []) {
+    if (!entry || !Array.isArray(entry.hooks)) continue;
+    const nonSsf = entry.hooks.filter(
+      h => !h || typeof h !== 'object' || !h.command || !h.command.includes('spec-superflow'),
+    );
+    if (nonSsf.length) {
+      preservedSessionEntries.push({ hooks: nonSsf });
+    }
+  }
+  // New ssf entry first, then preserved non-ssf entries.
+  merged.hooks.SessionStart = [...newConfig.hooks.SessionStart, ...preservedSessionEntries];
+
+  // Preserve top-level non-hook fields (e.g. description overrides, metadata).
+  for (const key of Object.keys(existing)) {
+    if (key === 'hooks') continue;
+    if (!(key in merged)) merged[key] = existing[key];
+  }
+  return merged;
+}
+
+// ─── release fetch / clone ────────────────────────────────
+
+async function fetchLatestTag() {
+  const res = await fetch(GITHUB_API_URL);
+  if (!res.ok) throw new Error(`GitHub API failed: ${res.status} ${res.statusText}`);
+  const data = await res.json();
+  if (!data.tag_name) throw new Error('GitHub API response missing tag_name');
+  return data.tag_name;
+}
+
+async function cloneRelease(tag) {
+  const tmpDir = await mkdtemp(join(tmpdir(), 'spec-superflow-'));
+  const url = `https://github.com/${GITHUB_REPO}.git`;
+  console.log(`📥 Cloning ${tag} into ${tmpDir} ...`);
+  execFileSync('git', ['clone', '--depth', '1', '--branch', tag, url, tmpDir], {
+    stdio: 'inherit',
+  });
+  return tmpDir;
+}
+
+function readVersion(pluginRoot) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf-8'));
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+// ─── plan ─────────────────────────────────────────────────
+
+function planInstall({ pluginRoot = defaultPluginRoot, configDir } = {}) {
+  const root = resolve(pluginRoot);
+  const skillsDir = join(root, 'skills');
+  const skillNames = listSkillNames(skillsDir);
+  const commandsDir = join(root, 'commands');
+  const commandAssets = snapshotCommandAssets(commandsDir);
+  const commandNames = commandAssets.map(asset => asset.relativePath.replace(/\.md$/, '').replace('/', ':'));
+  assertCanonicalCommands(commandNames);
+
+  const codebuddyRoot = getCodebuddyRoot(configDir);
+  const targetPluginDir = join(codebuddyRoot, PLUGIN_NAME);
+  const targetSkills = join(codebuddyRoot, 'skills');
+  const targetCommands = join(codebuddyRoot, 'commands');
+  const targetRules = join(codebuddyRoot, 'rules');
+  const targetHooks = join(codebuddyRoot, 'hooks');
+  const hooksJsonPath = join(targetHooks, 'hooks.json');
+  const version = readVersion(root);
+  const pluginRootAbs = resolve(targetPluginDir);
+  const sessionStartScript = join(pluginRootAbs, 'hooks', 'session-start');
+
+  return {
+    pluginRoot: root,
+    skillsDir,
+    skillNames,
+    commandsDir,
+    commandNames,
+    commandAssets,
+    codebuddyRoot,
+    targetPluginDir,
+    targetSkills,
+    targetCommands,
+    targetRules,
+    targetHooks,
+    hooksJsonPath,
+    version,
+    pluginRootAbs,
+    sessionStartScript,
+  };
+}
+
+// ─── install ──────────────────────────────────────────────
+
+async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = {}) {
+  const installPlan = providedPlan || planInstall({ pluginRoot, configDir });
+  const {
+    skillNames,
+    commandNames,
+    commandAssets,
+    codebuddyRoot,
+    targetPluginDir,
+    targetSkills,
+    targetCommands,
+    targetRules,
+    targetHooks,
+    hooksJsonPath,
+    version,
+    pluginRootAbs,
+    sessionStartScript,
+  } = installPlan;
+
+  // 0. Clean old plugin runtime dir (runtime deps only; skills are managed separately).
+  if (existsSync(targetPluginDir)) {
+    rmSync(targetPluginDir, { recursive: true, force: true });
+  }
+  ensureDir(targetPluginDir);
+
+  // 1. Copy runtime dependencies (scripts/docs/templates/dist/hooks).
+  console.log('📋 Copying runtime dependencies...');
+  for (const dir of RUNTIME_DIRS) {
+    const src = join(installPlan.pluginRoot, dir);
+    const dst = join(targetPluginDir, dir);
+    if (existsSync(src)) {
+      const count = await copyDir(src, dst);
+      console.log(`   ${dir}/ → ${dst} (${count} files)`);
+    } else {
+      console.log(`   ${dir}/ — skipped (not found)`);
+    }
+  }
+
+  // Also copy package.json for version identification.
+  const pkgSrc = join(installPlan.pluginRoot, 'package.json');
+  if (existsSync(pkgSrc)) {
+    await cp(pkgSrc, join(targetPluginDir, 'package.json'), { force: true });
+  }
+
+  // 2. Copy canonical recovery commands as complete Markdown assets.
+  const commandCount = await copyValidatedCommands(commandAssets, targetCommands);
+  console.log(`   commands/ → ${targetCommands} (${commandCount} files, ${commandNames.length} commands)`);
+
+  // 3. Copy skills with ${CLAUDE_PLUGIN_ROOT} rewriting (preserves unrelated skills).
+  const count = await copySkillsWithRoot(installPlan.skillsDir, targetSkills, pluginRootAbs, skillNames);
+  console.log(`   skills/ → ${targetSkills} (${count} skills, paths rewritten, unrelated skills preserved)`);
+
+  // 4. Write phase-guard rule (other rules in the directory are left untouched).
+  ensureDir(targetRules);
+  await writeFile(join(targetRules, 'phase-guard.md'), phaseGuardContent(), 'utf-8');
+  console.log(`   phase-guard → ${join(targetRules, 'phase-guard.md')}`);
+
+  // 5. Write/merge hooks.json (SessionStart hook).
+  ensureDir(targetHooks);
+  const hooksConfig = buildHooksJson(sessionStartScript);
+  const mergedHooks = mergeHooksJson(hooksJsonPath, hooksConfig);
+  await writeFile(hooksJsonPath, JSON.stringify(mergedHooks, null, 2) + '\n', 'utf-8');
+  console.log(`   hooks.json → ${hooksJsonPath}`);
+
+  return installPlan;
+}
+
+// ─── CLI entry ────────────────────────────────────────────
+
+export async function run(args) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      local: { type: 'string' },
+      'config-dir': { type: 'string' },
+      tag: { type: 'string' },
+      'dry-run': { type: 'boolean' },
+    },
+  });
+
+  // Dry-run: show plan and exit.
+  if (values['dry-run']) {
+    const plan = planInstall({
+      pluginRoot: values.local || defaultPluginRoot,
+      configDir: values['config-dir'],
+    });
+    console.log('CodeBuddy install plan:');
+    console.log(`  Plugin:      ${PLUGIN_NAME} v${plan.version}`);
+    console.log(`  Skills:      ${plan.skillNames.length} (${plan.skillNames.join(', ')})`);
+    console.log(`  Commands:    ${plan.commandNames.length} (${plan.commandNames.join(', ')})`);
+    console.log(`  Config dir:  ${plan.codebuddyRoot}`);
+    console.log(`  Plugin root: ${plan.targetPluginDir}`);
+    console.log(`  Skills dir:  ${plan.targetSkills}`);
+    console.log(`  Rules:       ${plan.targetRules}/phase-guard.md`);
+    console.log(`  Commands:    ${plan.targetCommands}`);
+    console.log(`  Hooks:       ${plan.hooksJsonPath}`);
+    return;
+  }
+
+  // Resolve source: --local <path> | --tag <tag> | latest release.
+  let pluginRoot = defaultPluginRoot;
+  let isTemp = false;
+  let installedTag = null;
+
+  if (values.local) {
+    pluginRoot = resolve(values.local);
+    console.log(`📁 Using local repo: ${pluginRoot}`);
+  } else {
+    installedTag = values.tag || await fetchLatestTag();
+    console.log(`⬆️  Installing spec-superflow ${installedTag} for CodeBuddy ...`);
+    pluginRoot = await cloneRelease(installedTag);
+    isTemp = true;
+  }
+
+  try {
+    const plan = await installCodeBuddy({
+      pluginRoot,
+      configDir: values['config-dir'],
+    });
+
+    console.log(`\n✅ CodeBuddy install complete:`);
+    console.log(`   Plugin:      ${PLUGIN_NAME} v${plan.version}`);
+    console.log(`   Skills:      ${plan.skillNames.length}`);
+    console.log(`   Commands:    ${plan.commandNames.length}`);
+    console.log(`   Config dir:  ${plan.codebuddyRoot}`);
+    console.log(`   Plugin root: ${plan.targetPluginDir}`);
+    console.log(`   Skills dir:  ${plan.targetSkills}`);
+    console.log(`   Rules:       ${plan.targetRules}/phase-guard.md`);
+    console.log(`   Hooks:       ${plan.hooksJsonPath}`);
+    if (installedTag) {
+      console.log(`   Version:     ${installedTag}`);
+    }
+    console.log(`\nNext: restart CodeBuddy Code CLI and try "用 workflow-start 开始".`);
+  } finally {
+    if (isTemp) {
+      rmSync(pluginRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+export { listCommandNames, planInstall, installCodeBuddy, PLUGIN_NAME };

--- a/scripts/lib/cmd-uninstall-codebuddy.mjs
+++ b/scripts/lib/cmd-uninstall-codebuddy.mjs
@@ -12,7 +12,7 @@
 // Other skills, rules, hooks, and settings entries are preserved. Supports
 // --dry-run to preview, --config-dir to target a non-default data directory.
 
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -126,10 +126,24 @@ export async function uninstallCodeBuddy({ configDir } = {}) {
     removed.push(plan.targetPluginDir);
   }
 
-  // 3. Remove recovery command adapters.
+  // 3. Remove only the managed recovery command files (resume/save/switch.md).
+  //    The shared ~/.codebuddy/commands/ssf/ directory may hold user-created
+  //    commands (e.g. custom.md); those must NOT be deleted. Only remove the
+  //    directory when it is empty after dropping the managed files.
+  const managedCommandFiles = ['resume.md', 'save.md', 'switch.md'];
+  for (const file of managedCommandFiles) {
+    const filePath = join(plan.targetCommands, file);
+    if (existsSync(filePath)) {
+      rmSync(filePath, { force: true });
+      removed.push(filePath);
+    }
+  }
   if (existsSync(plan.targetCommands)) {
-    rmSync(plan.targetCommands, { recursive: true, force: true });
-    removed.push(plan.targetCommands);
+    const remaining = readdirSync(plan.targetCommands).filter(name => !name.startsWith('.'));
+    if (remaining.length === 0) {
+      rmSync(plan.targetCommands, { recursive: true, force: true });
+      removed.push(plan.targetCommands);
+    }
   }
 
   // 4. Remove phase-guard rule (other rules untouched).

--- a/scripts/lib/cmd-uninstall-codebuddy.mjs
+++ b/scripts/lib/cmd-uninstall-codebuddy.mjs
@@ -1,0 +1,190 @@
+// ssf uninstall-codebuddy — remove spec-superflow from CodeBuddy Code CLI.
+//
+// Removes ONLY spec-superflow's own artifacts from ~/.codebuddy/:
+//   - The SessionStart hook entries referencing spec-superflow in
+//     settings.json (preserves other hooks and all other fields like
+//     permissions, enabledPlugins)
+//   - ~/.codebuddy/spec-superflow/ (runtime deps)
+//   - ~/.codebuddy/commands/ssf/ (recovery command adapters)
+//   - ~/.codebuddy/rules/phase-guard.md (leaves other rules untouched)
+//   - The 9 spec-superflow skill directories under ~/.codebuddy/skills/
+//
+// Other skills, rules, hooks, and settings entries are preserved. Supports
+// --dry-run to preview, --config-dir to target a non-default data directory.
+
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const PLUGIN_NAME = 'spec-superflow';
+
+// The 9 spec-superflow skills installed into ~/.codebuddy/skills/. Only these
+// are removed; unrelated skills in the shared directory are preserved. Keep in
+// sync with the skills/ directory in the spec-superflow source repo.
+const SPEC_SUPERFLOW_SKILLS = [
+  'workflow-start',
+  'build-executor',
+  'code-reviewer',
+  'contract-builder',
+  'need-explorer',
+  'release-archivist',
+  'spec-merger',
+  'spec-writer',
+  'bug-investigator',
+];
+
+function getCodebuddyRoot(configDir) {
+  if (configDir) return resolve(configDir);
+  return join(homedir(), '.codebuddy');
+}
+
+function readJsonIfExists(filePath) {
+  if (!existsSync(filePath)) return {};
+  return JSON.parse(readFileSync(filePath, 'utf-8'));
+}
+
+/**
+ * Return a new settings object with spec-superflow's SessionStart hook entries
+ * removed. Does not mutate the input. Other event hooks and all top-level
+ * fields (permissions, enabledPlugins, ...) are preserved. If the hooks object
+ * becomes empty, it is dropped.
+ */
+function stripSsfHooks(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const settings = { ...input };
+  if (!settings.hooks || typeof settings.hooks !== 'object' || Array.isArray(settings.hooks)) {
+    return settings;
+  }
+  const hooks = { ...settings.hooks };
+  if (!Array.isArray(hooks.SessionStart)) {
+    if (Object.keys(hooks).length === 0) delete settings.hooks;
+    else settings.hooks = hooks;
+    return settings;
+  }
+  const preservedEntries = [];
+  for (const entry of hooks.SessionStart) {
+    if (!entry || !Array.isArray(entry.hooks)) continue;
+    const nonSsf = entry.hooks.filter(
+      h => !h || typeof h !== 'object' || !h.command || !h.command.includes(PLUGIN_NAME),
+    );
+    if (nonSsf.length) {
+      preservedEntries.push({ ...entry, hooks: nonSsf });
+    }
+  }
+  if (preservedEntries.length) {
+    hooks.SessionStart = preservedEntries;
+  } else {
+    delete hooks.SessionStart;
+  }
+  if (Object.keys(hooks).length === 0) {
+    delete settings.hooks;
+  } else {
+    settings.hooks = hooks;
+  }
+  return settings;
+}
+
+function planUninstall({ configDir } = {}) {
+  const codebuddyRoot = getCodebuddyRoot(configDir);
+  const targetPluginDir = join(codebuddyRoot, PLUGIN_NAME);
+  const targetSkills = join(codebuddyRoot, 'skills');
+  const targetCommands = join(codebuddyRoot, 'commands', 'ssf');
+  const targetPhaseGuard = join(codebuddyRoot, 'rules', 'phase-guard.md');
+  const settingsPath = join(codebuddyRoot, 'settings.json');
+  return {
+    codebuddyRoot,
+    targetPluginDir,
+    targetSkills,
+    targetCommands,
+    targetPhaseGuard,
+    settingsPath,
+  };
+}
+
+export async function uninstallCodeBuddy({ configDir } = {}) {
+  const plan = planUninstall({ configDir });
+  const removed = [];
+
+  // 1. Strip spec-superflow SessionStart entries from settings.json (preserve
+  //    other hooks and all other fields).
+  if (existsSync(plan.settingsPath)) {
+    const originalText = readFileSync(plan.settingsPath, 'utf-8');
+    const original = JSON.parse(originalText);
+    const cleaned = stripSsfHooks(original);
+    const newText = JSON.stringify(cleaned, null, 2) + '\n';
+    if (newText !== originalText) {
+      await writeFile(plan.settingsPath, newText, 'utf-8');
+      removed.push(`${plan.settingsPath} (stripped spec-superflow SessionStart)`);
+    }
+  }
+
+  // 2. Remove runtime dir.
+  if (existsSync(plan.targetPluginDir)) {
+    rmSync(plan.targetPluginDir, { recursive: true, force: true });
+    removed.push(plan.targetPluginDir);
+  }
+
+  // 3. Remove recovery command adapters.
+  if (existsSync(plan.targetCommands)) {
+    rmSync(plan.targetCommands, { recursive: true, force: true });
+    removed.push(plan.targetCommands);
+  }
+
+  // 4. Remove phase-guard rule (other rules untouched).
+  if (existsSync(plan.targetPhaseGuard)) {
+    rmSync(plan.targetPhaseGuard, { force: true });
+    removed.push(plan.targetPhaseGuard);
+  }
+
+  // 5. Remove the 9 spec-superflow skill directories (other skills untouched).
+  if (existsSync(plan.targetSkills)) {
+    for (const name of SPEC_SUPERFLOW_SKILLS) {
+      const dir = join(plan.targetSkills, name);
+      if (existsSync(dir)) {
+        rmSync(dir, { recursive: true, force: true });
+        removed.push(dir);
+      }
+    }
+  }
+
+  return { plan, removed };
+}
+
+export async function run(args) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      'config-dir': { type: 'string' },
+      'dry-run': { type: 'boolean' },
+    },
+  });
+
+  const plan = planUninstall({ configDir: values['config-dir'] });
+
+  if (values['dry-run']) {
+    console.log('CodeBuddy uninstall plan:');
+    console.log(`  Config dir:  ${plan.codebuddyRoot}`);
+    console.log(`  Settings:    ${plan.settingsPath} (strip spec-superflow SessionStart, keep rest)`);
+    console.log(`  Runtime:     ${plan.targetPluginDir}`);
+    console.log(`  Commands:    ${plan.targetCommands}`);
+    console.log(`  Phase guard: ${plan.targetPhaseGuard}`);
+    console.log(`  Skills (${SPEC_SUPERFLOW_SKILLS.length}): ${SPEC_SUPERFLOW_SKILLS.join(', ')}`);
+    console.log(`  Other skills / rules / hooks / settings fields: preserved`);
+    return;
+  }
+
+  console.log(`🗑️  Uninstalling spec-superflow from ${plan.codebuddyRoot} ...`);
+  const { removed } = await uninstallCodeBuddy({ configDir: values['config-dir'] });
+
+  if (removed.length === 0) {
+    console.log(`\nℹ️  Nothing to remove — no spec-superflow artifacts found.`);
+  } else {
+    console.log(`\n✅ Removed ${removed.length} item(s):`);
+    for (const path of removed) console.log(`   - ${path}`);
+  }
+  console.log(`\nNext: restart CodeBuddy Code CLI to clear the cached hook snapshot (see /hooks).`);
+}
+
+export { planUninstall, stripSsfHooks, SPEC_SUPERFLOW_SKILLS };

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -36,6 +36,7 @@ const COMMANDS = {
   'install-qoder':    () => import('./lib/cmd-install-qoder.mjs'),
   'install-zcode':     () => import('./lib/cmd-install-zcode.mjs'),
   'install-codebuddy': () => import('./lib/cmd-install-codebuddy.mjs'),
+  'uninstall-codebuddy': () => import('./lib/cmd-uninstall-codebuddy.mjs'),
 };
 
 const HELP = `spec-superflow (ssf) — Spec-first workflow CLI
@@ -108,7 +109,8 @@ Commands:
   install-continue      Deploy to .continue/ + .continue/rules/ (Continue)
   install-pi            Deploy to .pi/skills/ (Pi agent; no rules dir)
   install-qoder         Deploy to .qoder/ + .qoder/rules/ (Qoder)
-  install-codebuddy     Deploy to ~/.codebuddy/skills/ + hooks (CodeBuddy Code CLI)
+  install-codebuddy     Deploy to ~/.codebuddy/skills/ + settings.json (CodeBuddy Code CLI)
+  uninstall-codebuddy   Remove spec-superflow from ~/.codebuddy/ (CodeBuddy Code CLI)
 
 Options:
   --help, -h            Show this help message
@@ -139,6 +141,7 @@ Examples:
   ssf install-workbuddy
   ssf install-cline --local /path/to/spec-superflow
   ssf install-codebuddy
+  ssf uninstall-codebuddy --dry-run
 `;
 
 async function main() {

--- a/scripts/spec-superflow.mjs
+++ b/scripts/spec-superflow.mjs
@@ -35,6 +35,7 @@ const COMMANDS = {
   'install-pi':       () => import('./lib/cmd-install-pi.mjs'),
   'install-qoder':    () => import('./lib/cmd-install-qoder.mjs'),
   'install-zcode':     () => import('./lib/cmd-install-zcode.mjs'),
+  'install-codebuddy': () => import('./lib/cmd-install-codebuddy.mjs'),
 };
 
 const HELP = `spec-superflow (ssf) — Spec-first workflow CLI
@@ -107,6 +108,7 @@ Commands:
   install-continue      Deploy to .continue/ + .continue/rules/ (Continue)
   install-pi            Deploy to .pi/skills/ (Pi agent; no rules dir)
   install-qoder         Deploy to .qoder/ + .qoder/rules/ (Qoder)
+  install-codebuddy     Deploy to ~/.codebuddy/skills/ + hooks (CodeBuddy Code CLI)
 
 Options:
   --help, -h            Show this help message
@@ -136,6 +138,7 @@ Examples:
   ssf install-cursor
   ssf install-workbuddy
   ssf install-cline --local /path/to/spec-superflow
+  ssf install-codebuddy
 `;
 
 async function main() {

--- a/tests/lib/closing-terminal-semantics.test.mjs
+++ b/tests/lib/closing-terminal-semantics.test.mjs
@@ -193,7 +193,10 @@ describe('closing terminal lifecycle', () => {
     const unreleased = section(changelog, '## [Unreleased]');
     const repairedRelease = section(changelog, '## [0.11.0] - 2026-07-21');
 
-    assert.equal(unreleased.trim(), '## [Unreleased]');
+    // The #64 repair must remain in its v0.11.0 record; [Unreleased] may carry
+    // other pending changes (e.g. the CodeBuddy installer), so we only assert
+    // the #64 repair was not leaked into [Unreleased].
+    assert.doesNotMatch(unreleased, /#64/, 'the #64 repair must stay in v0.11.0, not in [Unreleased]');
     assert.match(repairedRelease, /#64/);
     assert.match(repairedRelease, /closing/i);
     assert.match(repairedRelease, /终态/);

--- a/tests/lib/cmd-install-codebuddy.test.mjs
+++ b/tests/lib/cmd-install-codebuddy.test.mjs
@@ -1,0 +1,299 @@
+// tests/lib/cmd-install-codebuddy.test.mjs
+// Tests for scripts/lib/cmd-install-codebuddy.mjs and cmd-uninstall-codebuddy.mjs
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+
+// Windows-safe dynamic import: bare Windows paths (D:\...) are not valid ESM
+// import specifiers, so convert to a file:// URL. No-op on POSIX.
+async function loadModule(relPath) {
+  return import(pathToFileURL(join(process.cwd(), relPath)).href);
+}
+
+let tempDir;
+let planInstall, installCodeBuddy, planUninstall, uninstallCodeBuddy;
+
+describe('cmd-install-codebuddy', () => {
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ssf-codebuddy-'));
+    const installMod = await loadModule('scripts/lib/cmd-install-codebuddy.mjs');
+    planInstall = installMod.planInstall;
+    installCodeBuddy = installMod.installCodeBuddy;
+    const uninstallMod = await loadModule('scripts/lib/cmd-uninstall-codebuddy.mjs');
+    planUninstall = uninstallMod.planUninstall;
+    uninstallCodeBuddy = uninstallMod.uninstallCodeBuddy;
+  });
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  // Build a minimal plugin root with the canonical command tree and 2 skills.
+  // The command files use the real npx form so the rewrite is exercised.
+  function makePluginRoot({ skills = ['workflow-start', 'need-explorer'], commands = ['resume', 'save', 'switch'] } = {}) {
+    const pluginRoot = join(tempDir, 'spec-superflow');
+    const skillsDir = join(pluginRoot, 'skills');
+    for (const name of skills) {
+      mkdirSync(join(skillsDir, name), { recursive: true });
+      writeFileSync(join(skillsDir, name, 'SKILL.md'), `---\nname: ${name}\n---\n`);
+    }
+    for (const command of commands) {
+      const commandFile = join(pluginRoot, 'commands', 'ssf', `${command}.md`);
+      mkdirSync(join(commandFile, '..'), { recursive: true });
+      writeFileSync(commandFile, `---\n\ndescription: ${command} command\nargument-hint: "<change>"\nallowed-tools: Bash(npx:*)\n---\n\nRun \`npx --yes --package spec-superflow@0.12.1 ssf ${command} --json "$ARGUMENTS"\` and report.\n`);
+    }
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '0.12.1' }));
+    // A scripts/ dir so RUNTIME_DIRS copy has at least one file.
+    mkdirSync(join(pluginRoot, 'scripts'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'scripts', 'spec-superflow.mjs'), '// test runtime entry');
+    return pluginRoot;
+  }
+
+  it('plans CodeBuddy paths with settings.json (not hooks.json)', () => {
+    const pluginRoot = makePluginRoot();
+    const plan = planInstall({ pluginRoot, configDir: join(tempDir, 'cb') });
+    assert.equal(plan.settingsPath, join(tempDir, 'cb', 'settings.json'));
+    assert.equal(plan.targetPluginDir, join(tempDir, 'cb', 'spec-superflow'));
+    assert.equal(plan.targetCommands, join(tempDir, 'cb', 'commands'));
+    assert.deepEqual(plan.commandNames, ['ssf:resume', 'ssf:save', 'ssf:switch']);
+    assert.equal(plan.sessionStartScript, join(plan.targetPluginDir, 'hooks', 'session-start'));
+  });
+
+  it('deploys skills, runtime, rules, and merges SessionStart into settings.json', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    // skills
+    assert.ok(existsSync(join(configDir, 'skills', 'workflow-start', 'SKILL.md')));
+    assert.ok(existsSync(join(configDir, 'skills', 'need-explorer', 'SKILL.md')));
+
+    // runtime copied
+    assert.ok(existsSync(join(configDir, 'spec-superflow', 'scripts', 'spec-superflow.mjs')));
+
+    // settings.json with SessionStart pointing at deployed hook
+    const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8'));
+    const ssfEntry = settings.hooks.SessionStart.find(e =>
+      Array.isArray(e.hooks) && e.hooks.some(h => h.command && h.command.includes('spec-superflow')),
+    );
+    assert.ok(ssfEntry, 'expected a spec-superflow SessionStart entry');
+    assert.match(ssfEntry.hooks[0].command, /bash .+spec-superflow\/hooks\/session-start/);
+
+    // phase-guard rule with alwaysApply:false frontmatter
+    const phaseGuard = readFileSync(join(configDir, 'rules', 'phase-guard.md'), 'utf-8');
+    assert.match(phaseGuard, /^---\nalwaysApply: false\n---/);
+
+    // user-level hooks.json must NOT be written (CodeBuddy does not load it)
+    assert.ok(!existsSync(join(configDir, 'hooks', 'hooks.json')));
+  });
+
+  it('rewrites --local recovery commands to use the deployed local runtime', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    for (const name of ['resume', 'save', 'switch']) {
+      const content = readFileSync(join(configDir, 'commands', 'ssf', `${name}.md`), 'utf-8');
+      // npx --package is gone
+      assert.doesNotMatch(content, /npx --yes --package spec-superflow@\d+\.\d+\.\d+ ssf/);
+      // replaced by node calling the deployed spec-superflow.mjs runtime, then the subcommand
+      assert.match(content, /node .+spec-superflow[\\/]+scripts[\\/]+spec-superflow\.mjs/);
+      assert.match(content, new RegExp(`${name} --json`));
+      // allowed-tools switched from npx to node
+      assert.match(content, /allowed-tools: Bash\(node:\*\)/);
+      assert.doesNotMatch(content, /Bash\(npx:\*\)/);
+    }
+  });
+
+  it('preserves existing settings.json fields and non-ssf SessionStart hooks', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    mkdirSync(configDir, { recursive: true });
+    const existing = {
+      permissions: { allow: ['Read'], deny: ['Read(./.env)'] },
+      enabledPlugins: { 'other@market': true },
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: 'echo user-start' }] }],
+        PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo pre' }] }],
+      },
+    };
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify(existing, null, 2));
+
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8'));
+    // other top-level fields preserved
+    assert.deepEqual(settings.permissions, existing.permissions);
+    assert.equal(settings.enabledPlugins['other@market'], true);
+    // other event types preserved
+    assert.ok(settings.hooks.PreToolUse);
+    // non-ssf SessionStart entry preserved
+    const userEntries = settings.hooks.SessionStart.filter(e =>
+      Array.isArray(e.hooks) && e.hooks.every(h => !h.command.includes('spec-superflow')),
+    );
+    assert.equal(userEntries.length, 1);
+    // ssf SessionStart entry present
+    const ssfEntries = settings.hooks.SessionStart.filter(e =>
+      Array.isArray(e.hooks) && e.hooks.some(h => h.command.includes('spec-superflow')),
+    );
+    assert.equal(ssfEntries.length, 1);
+  });
+
+  it('preserves unrelated skills in the shared skills directory', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    const skillsDir = join(configDir, 'skills');
+    mkdirSync(join(skillsDir, 'other-skill'), { recursive: true });
+    writeFileSync(join(skillsDir, 'other-skill', 'SKILL.md'), '---\nname: other-skill\n---\n');
+
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    assert.ok(existsSync(join(skillsDir, 'other-skill', 'SKILL.md')), 'other skill preserved');
+    assert.ok(existsSync(join(skillsDir, 'workflow-start', 'SKILL.md')), 'ssf skill deployed');
+  });
+
+  it('re-running install upgrades in place without duplicating SessionStart', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8'));
+    const ssfEntries = settings.hooks.SessionStart.filter(e =>
+      Array.isArray(e.hooks) && e.hooks.some(h => h.command.includes('spec-superflow')),
+    );
+    assert.equal(ssfEntries.length, 1, 'SessionStart ssf entry must not duplicate');
+  });
+
+  it('run --dry-run writes nothing to disk', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb-dry');
+    const mod = await loadModule('scripts/lib/cmd-install-codebuddy.mjs');
+    await mod.run(['--dry-run', '--local', pluginRoot, '--config-dir', configDir]);
+    assert.ok(!existsSync(configDir), 'dry-run must not create the config dir');
+  });
+
+  it('throws when the commands tree is missing', () => {
+    const pluginRoot = join(tempDir, 'bad-root');
+    mkdirSync(join(pluginRoot, 'skills', 'workflow-start'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'skills', 'workflow-start', 'SKILL.md'), '---\nname: workflow-start\n---\n');
+    writeFileSync(join(pluginRoot, 'package.json'), '{}');
+    assert.throws(() => planInstall({ pluginRoot }), /commands\/ directory not found/);
+  });
+});
+
+describe('hooks/session-start output format', () => {
+  const scriptPath = join(process.cwd(), 'hooks', 'session-start');
+
+  it('outputs hookSpecificOutput under CODEBUDDY_PROJECT_DIR', () => {
+    const out = execFileSync('bash', [scriptPath], {
+      env: { ...process.env, CODEBUDDY_PROJECT_DIR: '/tmp/cb-project' },
+    }).toString();
+    assert.match(out, /"hookSpecificOutput"/);
+    assert.match(out, /"hookEventName": "SessionStart"/);
+    assert.match(out, /"additionalContext"/);
+  });
+
+  it('falls back to top-level additionalContext when no platform env is set', () => {
+    const { PATH = '' } = process.env;
+    const out = execFileSync('bash', [scriptPath], {
+      env: { PATH },
+    }).toString();
+    // No CURSOR/CLAUDE/CODEBUDDY env → else branch → top-level additionalContext.
+    assert.match(out, /"additionalContext"/);
+    assert.doesNotMatch(out, /"hookSpecificOutput"/);
+  });
+});
+
+describe('cmd-uninstall-codebuddy', () => {
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ssf-cb-uninstall-'));
+    const installMod = await loadModule('scripts/lib/cmd-install-codebuddy.mjs');
+    planInstall = installMod.planInstall;
+    installCodeBuddy = installMod.installCodeBuddy;
+    const uninstallMod = await loadModule('scripts/lib/cmd-uninstall-codebuddy.mjs');
+    planUninstall = uninstallMod.planUninstall;
+    uninstallCodeBuddy = uninstallMod.uninstallCodeBuddy;
+  });
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makePluginRoot() {
+    const pluginRoot = join(tempDir, 'spec-superflow');
+    for (const name of ['workflow-start', 'need-explorer']) {
+      mkdirSync(join(pluginRoot, 'skills', name), { recursive: true });
+      writeFileSync(join(pluginRoot, 'skills', name, 'SKILL.md'), `---\nname: ${name}\n---\n`);
+    }
+    for (const command of ['resume', 'save', 'switch']) {
+      const f = join(pluginRoot, 'commands', 'ssf', `${command}.md`);
+      mkdirSync(join(f, '..'), { recursive: true });
+      writeFileSync(f, `---\nallowed-tools: Bash(npx:*)\n---\nnpx --yes --package spec-superflow@0.12.1 ssf ${command}\n`);
+    }
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ version: '0.12.1' }));
+    return pluginRoot;
+  }
+
+  it('removes only spec-superflow artifacts and preserves other settings/hooks/skills', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    // Seed unrelated skill, rule, and SessionStart hook + settings field.
+    const skillsDir = join(configDir, 'skills');
+    mkdirSync(join(skillsDir, 'other-skill'), { recursive: true });
+    writeFileSync(join(skillsDir, 'other-skill', 'SKILL.md'), '---\nname: other-skill\n---\n');
+    mkdirSync(join(configDir, 'rules'), { recursive: true });
+    writeFileSync(join(configDir, 'rules', 'other-rule.md'), '# other rule');
+    const settingsPath = join(configDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    settings.hooks.SessionStart.push({ hooks: [{ type: 'command', command: 'echo user-start' }] });
+    settings.enabledPlugins = { 'other@market': true };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+    const { removed } = await uninstallCodeBuddy({ configDir });
+    assert.ok(removed.length > 0);
+
+    // spec-superflow artifacts gone
+    assert.ok(!existsSync(join(configDir, 'spec-superflow')));
+    assert.ok(!existsSync(join(configDir, 'commands', 'ssf')));
+    assert.ok(!existsSync(join(configDir, 'rules', 'phase-guard.md')));
+    assert.ok(!existsSync(join(skillsDir, 'workflow-start')));
+
+    // unrelated artifacts preserved
+    assert.ok(existsSync(join(skillsDir, 'other-skill', 'SKILL.md')));
+    assert.ok(existsSync(join(configDir, 'rules', 'other-rule.md')));
+
+    // settings.json still exists, ssf hook removed, user hook + enabledPlugins preserved
+    const after = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    assert.equal(after.enabledPlugins['other@market'], true);
+    const ssfAfter = (after.hooks?.SessionStart || []).filter(e =>
+      Array.isArray(e.hooks) && e.hooks.some(h => h.command.includes('spec-superflow')),
+    );
+    assert.equal(ssfAfter.length, 0);
+    const userAfter = (after.hooks?.SessionStart || []).filter(e =>
+      Array.isArray(e.hooks) && e.hooks.some(h => !h.command.includes('spec-superflow')),
+    );
+    assert.equal(userAfter.length, 1);
+  });
+
+  it('is safe when nothing is installed', async () => {
+    const configDir = join(tempDir, 'empty-cb');
+    const { removed } = await uninstallCodeBuddy({ configDir });
+    assert.equal(removed.length, 0);
+  });
+
+  it('run --dry-run writes nothing', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+    const mod = await loadModule('scripts/lib/cmd-uninstall-codebuddy.mjs');
+    await mod.run(['--dry-run', '--config-dir', configDir]);
+    assert.ok(existsSync(join(configDir, 'spec-superflow')), 'dry-run must not delete artifacts');
+  });
+});

--- a/tests/lib/cmd-install-codebuddy.test.mjs
+++ b/tests/lib/cmd-install-codebuddy.test.mjs
@@ -39,7 +39,11 @@ describe('cmd-install-codebuddy', () => {
     const skillsDir = join(pluginRoot, 'skills');
     for (const name of skills) {
       mkdirSync(join(skillsDir, name), { recursive: true });
-      writeFileSync(join(skillsDir, name, 'SKILL.md'), `---\nname: ${name}\n---\n`);
+      // workflow-start carries an npx invocation so the install rewrite is exercised.
+      const body = name === 'workflow-start'
+        ? `---\nname: ${name}\n---\nRun \`npx --yes --package spec-superflow@0.12.1 ssf state init <change-dir>\`\n`
+        : `---\nname: ${name}\n---\n`;
+      writeFileSync(join(skillsDir, name, 'SKILL.md'), body);
     }
     for (const command of commands) {
       const commandFile = join(pluginRoot, 'commands', 'ssf', `${command}.md`);
@@ -107,6 +111,16 @@ describe('cmd-install-codebuddy', () => {
       assert.match(content, /allowed-tools: Bash\(node:\*\)/);
       assert.doesNotMatch(content, /Bash\(npx:\*\)/);
     }
+  });
+
+  it('rewrites npx invocations in deployed skills to use the local runtime', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+    const skillMd = readFileSync(join(configDir, 'skills', 'workflow-start', 'SKILL.md'), 'utf-8');
+    // Source SKILL.md used npx --yes --package spec-superflow@0.12.1 ssf; deployed must use node <pluginRoot>/scripts/spec-superflow.mjs
+    assert.doesNotMatch(skillMd, /npx --yes --package spec-superflow@\d+\.\d+\.\d+ ssf/);
+    assert.match(skillMd, /node .+spec-superflow[\\/]+scripts[\\/]+spec-superflow\.mjs/);
   });
 
   it('preserves existing settings.json fields and non-ssf SessionStart hooks', async () => {
@@ -224,9 +238,9 @@ describe('cmd-uninstall-codebuddy', () => {
     if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   });
 
-  function makePluginRoot() {
+  function makePluginRoot({ skills = ['workflow-start', 'need-explorer'] } = {}) {
     const pluginRoot = join(tempDir, 'spec-superflow');
-    for (const name of ['workflow-start', 'need-explorer']) {
+    for (const name of skills) {
       mkdirSync(join(pluginRoot, 'skills', name), { recursive: true });
       writeFileSync(join(pluginRoot, 'skills', name, 'SKILL.md'), `---\nname: ${name}\n---\n`);
     }
@@ -280,6 +294,39 @@ describe('cmd-uninstall-codebuddy', () => {
       Array.isArray(e.hooks) && e.hooks.some(h => !h.command.includes('spec-superflow')),
     );
     assert.equal(userAfter.length, 1);
+  });
+
+  it('preserves user-created commands/ssf/custom.md and only removes managed files', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+
+    // Seed a user-created command in the shared commands/ssf/ directory.
+    const ssfCommandsDir = join(configDir, 'commands', 'ssf');
+    mkdirSync(ssfCommandsDir, { recursive: true });
+    writeFileSync(join(ssfCommandsDir, 'custom.md'), '---\ndescription: user command\n---\nbody\n');
+
+    await uninstallCodeBuddy({ configDir });
+
+    // Managed files removed
+    assert.ok(!existsSync(join(ssfCommandsDir, 'resume.md')), 'resume.md removed');
+    assert.ok(!existsSync(join(ssfCommandsDir, 'save.md')), 'save.md removed');
+    assert.ok(!existsSync(join(ssfCommandsDir, 'switch.md')), 'switch.md removed');
+    // User-created command preserved
+    assert.ok(existsSync(join(ssfCommandsDir, 'custom.md')), 'custom.md preserved');
+    // Directory preserved because it is non-empty
+    assert.ok(existsSync(ssfCommandsDir), 'commands/ssf dir preserved (non-empty)');
+  });
+
+  it('removes all 9 spec-superflow skill directories on uninstall', async () => {
+    const allSkills = ['workflow-start','build-executor','code-reviewer','contract-builder','need-explorer','release-archivist','spec-merger','spec-writer','bug-investigator'];
+    const pluginRoot = makePluginRoot({ skills: allSkills });
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir });
+    await uninstallCodeBuddy({ configDir });
+    for (const name of allSkills) {
+      assert.ok(!existsSync(join(configDir, 'skills', name)), `${name} skill removed`);
+    }
   });
 
   it('is safe when nothing is installed', async () => {


### PR DESCRIPTION
## 修改内容

新增 `install-codebuddy` 安装脚本，支持将 spec-superflow 部署到 CodeBuddy Code CLI（`~/.codebuddy/skills/ + hooks`）。

### 新增文件
- `scripts/install-codebuddy.mjs` — 独立入口脚本
- `scripts/lib/cmd-install-codebuddy.mjs` — 安装命令模块

### 修改文件
- `scripts/spec-superflow.mjs` — 注册 `install-codebuddy` 命令、help 描述、使用示例
- `INSTALL.md` — 新增 `## CodeBuddy Code CLI` 章节（安装/升级/卸载/验证/部署结构）

### 功能特点
- 从 GitHub release 或本地源码部署 spec-superflow 到 CodeBuddy Code CLI
- skills 安装到 `~/.codebuddy/skills/`，不覆盖其他 skill（如 `project-init`）
- 运行时依赖安装到 `~/.codebuddy/spec-superflow/`
- phase-guard 规则安装到 `~/.codebuddy/rules/phase-guard.md`
- SessionStart hook 自动配置到 `~/.codebuddy/hooks/hooks.json`
- canonical recovery commands 部署到 `~/.codebuddy/commands/ssf/`
- 支持 `--local`、`--tag`、`--config-dir`、`--dry-run` 参数