### PR TITLE
ci: gate releases on marketplace sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
       - run: npm test
       - name: Check version consistency
         run: node scripts/check-version-consistency.mjs
+      - name: Verify marketplace release gate
+        env:
+          EXPECTED_VERSION: ${{ github.ref_name }}
+        run: |
+          node scripts/verify-marketplace-release.mjs \
+            --manifest-url https://raw.githubusercontent.com/hashgraph-online/awesome-codex-plugins/main/plugins/MageByte-Zero/spec-superflow/.codex-plugin/plugin.json \
+            --expected-version "${EXPECTED_VERSION#v}"
       - name: Token efficiency lint (warning only)
         run: node scripts/lint/lint-skills.mjs --include token
         continue-on-error: true

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -95,6 +95,8 @@ For each example in `docs/examples/`:
     --expected-version <semver>
   ```
 
+- This check is a **blocking release CI gate**: the upstream marketplace PR must be submitted and merged, and its generated manifest must report the release version, before pushing the `v<semver>` tag. The gate runs before GitHub Release creation and npm publishing.
+
 - Use one 干净 Codex configuration directory for marketplace add, plugin add, and plugin list:
 
   ```bash

--- a/tests/lib/marketplace-release-gate.test.mjs
+++ b/tests/lib/marketplace-release-gate.test.mjs
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const workflow = readFileSync('.github/workflows/ci.yml', 'utf8');
+
+describe('marketplace release gate', () => {
+  it('blocks tagged releases until the marketplace manifest matches the tag version', () => {
+    const releaseJob = workflow.indexOf('\n  release:\n');
+    const gate = workflow.indexOf('name: Verify marketplace release gate');
+    const githubRelease = workflow.indexOf('name: Create GitHub Release');
+    const npmPublish = workflow.indexOf('name: Publish to npm');
+
+    assert.ok(releaseJob >= 0, 'workflow must define a release job');
+    assert.ok(gate >= 0, 'release workflow must verify marketplace delivery');
+    assert.ok(gate > releaseJob, 'marketplace verification must remain in the release job');
+    assert.doesNotMatch(workflow.slice(0, releaseJob), /name: Verify marketplace release gate/);
+    assert.match(workflow.slice(releaseJob), /if: startsWith\(github\.ref, 'refs\/tags\/v'\)/);
+    assert.ok(gate < githubRelease, 'marketplace verification must run before GitHub Release creation');
+    assert.ok(gate < npmPublish, 'marketplace verification must run before npm publish');
+    assert.match(workflow, /EXPECTED_VERSION: \$\{\{ github\.ref_name \}\}/);
+    assert.match(workflow, /verify-marketplace-release\.mjs[\s\S]*--expected-version "\$\{EXPECTED_VERSION#v\}"/);
+    assert.match(workflow, /hashgraph-online\/awesome-codex-plugins\/main\/plugins\/MageByte-Zero\/spec-superflow\/\.codex-plugin\/plugin\.json/);
+  });
+});


### PR DESCRIPTION
## Summary

- block tag releases until the awesome-codex-plugins manifest matches the tag version
- run the gate before GitHub Release creation and npm publishing
- document the required upstream PR / generator sequence
- cover tag-only placement and ordering with a regression test

## Verification

- `npm test`
- `npm run validate`
- independent review (including a follow-up review after the tag-only test repair)

Tracking upstream marketplace sync: https://github.com/hashgraph-online/awesome-codex-plugins/pull/331