### PR TITLE
docs: prevent stale marketplace sync PRs

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -97,6 +97,14 @@ For each example in `docs/examples/`:
 
 - This check is a **blocking release CI gate**: the upstream marketplace PR must be submitted and merged, and its generated manifest must report the release version, before pushing the `v<semver>` tag. The gate runs before GitHub Release creation and npm publishing.
 
+- Before creating the marketplace sync branch, fast-forward the personal fork to the upstream default branch. After opening the PR, verify its diff is limited to the intended catalog entry (normally `README.md`); do not carry generated marketplace files or unrelated fork history into the PR.
+
+  ```bash
+  gh repo sync MageByte-Zero/awesome-codex-plugins \
+    --source hashgraph-online/awesome-codex-plugins
+  gh pr diff <pr-number> --repo hashgraph-online/awesome-codex-plugins --name-only
+  ```
+
 - Use one 干净 Codex configuration directory for marketplace add, plugin add, and plugin list:
 
   ```bash

--- a/tests/lib/marketplace-release-docs.test.mjs
+++ b/tests/lib/marketplace-release-docs.test.mjs
@@ -27,5 +27,7 @@ describe('marketplace release documentation', () => {
     assert.match(checklist, /verify-marketplace-release/);
     assert.match(checklist, /同步 PR/);
     assert.match(checklist, /干净 Codex/);
+    assert.match(checklist, /gh repo sync MageByte-Zero\/awesome-codex-plugins/);
+    assert.match(checklist, /gh pr diff <pr-number> --repo hashgraph-online\/awesome-codex-plugins --name-only/);
   });
 });


### PR DESCRIPTION
## Summary

- require fast-forwarding the marketplace fork before opening a release-sync PR
- require verifying the PR only changes the intended catalog entry
- cover these release-checklist requirements with the existing marketplace documentation test

## Verification

- `node --test tests/lib/marketplace-release-docs.test.mjs tests/lib/marketplace-release-gate.test.mjs`

Related: upstream marketplace release PR #333 has been verified as README-only.