### PR TITLE
test: align CI assertions with plan-scoped execution receipts

### DIFF
--- a/tests/lib/cmd-execution.test.mjs
+++ b/tests/lib/cmd-execution.test.mjs
@@ -4,6 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { getPlanScopedPaths } from '../../scripts/lib/sdd-overlay.mjs';
 
 const CLI = join(process.cwd(), 'scripts/spec-superflow.mjs');
 let changeDir;
@@ -85,6 +86,11 @@ function writeReviewReport(name, content = 'Review completed without blocking fi
   const reportPath = join(reportsDir, name);
   writeFileSync(reportPath, content);
   return reportPath;
+}
+
+function currentReceiptPath(waveId) {
+  const plan = JSON.parse(readFileSync(join(changeDir, '.superpowers', 'sdd', 'execution-plan.json'), 'utf8'));
+  return join(getPlanScopedPaths(changeDir, plan).reviews, `${Buffer.from(waveId, 'utf8').toString('base64url')}.json`);
 }
 
 function initializeGitRepository(directory) {
@@ -246,6 +252,7 @@ describe('ssf execution', () => {
       retryable: false,
       receipt: null,
       blockers: [],
+      repair: { status: 'not-needed', failure_count: 0, previous_head: null, previous_report: null, failures: [] },
     }]);
   });
 
@@ -363,7 +370,7 @@ describe('ssf execution', () => {
       '--base', gitRefs.base, '--head', gitRefs.head, '--report', writeReviewReport('wave-1.md'), '--verdict', 'pass']);
     assert.equal(reviewed.exitCode, 0, reviewed.stderr);
 
-    const receiptPath = join(changeDir, '.superpowers', 'sdd', 'reviews', Buffer.from('wave-1', 'utf8').toString('base64url') + '.json');
+    const receiptPath = currentReceiptPath('wave-1');
     const receipt = JSON.parse(readFileSync(receiptPath, 'utf8'));
     receipt.base = '0000000000000000000000000000000000000001';
     writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
@@ -383,7 +390,7 @@ describe('ssf execution', () => {
       '--base', gitRefs.base, '--head', gitRefs.head, '--report', writeReviewReport('wave-1.md'), '--verdict', 'pass']);
     assert.equal(reviewed.exitCode, 0, reviewed.stderr);
 
-    const receiptPath = join(changeDir, '.superpowers', 'sdd', 'reviews', Buffer.from('wave-1', 'utf8').toString('base64url') + '.json');
+    const receiptPath = currentReceiptPath('wave-1');
     const receipt = JSON.parse(readFileSync(receiptPath, 'utf8'));
     receipt.base = gitRefs.head;
     receipt.head = gitRefs.divergent;

--- a/tests/lib/guard.test.mjs
+++ b/tests/lib/guard.test.mjs
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
 import { acceptWorkflowRecommendation, saveWorkflowRecommendation } from '../../scripts/lib/workflow-recommendation.mjs';
+import { getPlanScopedPaths } from '../../scripts/lib/sdd-overlay.mjs';
 
 let tempDir;
 let gitRefs;
@@ -654,7 +655,8 @@ describe('guard: execution control records', () => {
       {
         name: 'control-character path',
         replace: reportPath => {
-          const receiptPath = join(dir, '.superpowers', 'sdd', 'reviews', `${Buffer.from('wave-1').toString('base64url')}.json`);
+          const plan = JSON.parse(readFileSync(join(dir, '.superpowers', 'sdd', 'execution-plan.json'), 'utf8'));
+          const receiptPath = join(getPlanScopedPaths(dir, plan).reviews, `${Buffer.from('wave-1').toString('base64url')}.json`);
           const receipt = JSON.parse(readFileSync(receiptPath, 'utf8'));
           receipt.report = `${reportPath}\nforged`;
           writeFileSync(receiptPath, `${JSON.stringify(receipt)}\n`);


### PR DESCRIPTION
## Fix
- assert the execution show response includes persisted repair state
- tamper with the authoritative plan-scoped review receipt in safety tests
- retain guard coverage for forged receipt evidence

## Verification
- `node --test tests/lib/cmd-execution.test.mjs tests/lib/guard.test.mjs` (70/70)