### PR TITLE
release: prepare v1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "0.12.1",
+      "version": "1.0.0",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v0.12.1 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v1.0.0 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "0.12.1"
+    "version": "1.0.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "0.12.1"
+    "version": "1.0.0"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "0.12.1",
+      "version": "1.0.0",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,22 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-03
+
 ### Added
 
 - **CodeBuddy Code CLI installer**: `ssf install-codebuddy` deploys spec-superflow to `~/.codebuddy/` for CodeBuddy Code CLI. SessionStart hook is written to `~/.codebuddy/settings.json` (CodeBuddy's canonical hook location — the user-level `hooks/hooks.json` is not auto-loaded), recovery command adapters are rewritten to call the deployed local runtime instead of a pinned `npx` package, and `phase-guard.md` uses `alwaysApply:false` frontmatter so ordinary projects are not forced into the workflow. Adds `ssf uninstall-codebuddy` for precise, safe teardown.
+- **Risk-adaptive execution**: Quick, direct Hotfix, Tweak, and Full paths now keep small changes bounded and reserve contracts, plans, and review receipts for higher-risk work.
+
+### Changed
+
+- **Faster test and review path**: reuses immutable Git validation and removes redundant test work, reducing the full local suite to about 141 seconds in the release-candidate run.
+- **Clearer documentation**: Chinese and English homepages now lead with path selection, verification, and user-visible tradeoffs instead of workflow jargon.
 
 ### Fixed
 
 - **CodeBuddy install/teardown safety**: `ssf uninstall-codebuddy` precisely removes spec-superflow's own artifacts (SessionStart entries in `settings.json`, runtime dir, commands, phase-guard rule, 9 skills) while preserving other skills, rules, hooks, and settings fields. The previous `rm -f ~/.codebuddy/hooks/hooks.json` advice, which deleted unrelated hooks, is replaced by the dedicated uninstall command. CI `platform-install-smoke` now covers CodeBuddy (settings.json SessionStart, command rewrite, phase-guard frontmatter).
+- **Major-version release sync**: `ssf version` now preserves the requested major version when it updates documentation and runtime markers, so `ssf version 1.0.0` cannot produce `0.0.0`.
 
 ## [0.12.1] - 2026-07-27
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v0.12.1 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v1.0.0 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v0.12.1**。
+当前发布版本：**v1.0.0**。
 
 ---
 
@@ -169,7 +169,7 @@ codex plugin add spec-superflow@awesome-codex-plugins
 当社区 marketplace 镜像尚未同步时，可直接指定本仓库的 release tag：
 
 ```bash
-codex plugin marketplace add MageByte-Zero/spec-superflow --ref v0.9.0
+codex plugin marketplace add MageByte-Zero/spec-superflow --ref v1.0.0
 codex plugin add spec-superflow@spec-superflow
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">spec-superflow</h1>
 
 <p align="center">
-  <strong>源码级融合 OpenSpec 规划引擎 + Superpowers 执行纪律的 AI 编程工作流插件</strong>
+  <strong>按改动风险选择轻量或完整路径的 AI 编程工作流插件</strong>
 </p>
 
 <p align="center">
@@ -77,7 +77,7 @@ codex plugin marketplace add hashgraph-online/awesome-codex-plugins
 codex plugin add spec-superflow@awesome-codex-plugins
 
 # 直接从指定 release tag 安装（不等待社区镜像同步）
-codex plugin marketplace add MageByte-Zero/spec-superflow --ref v0.9.0
+codex plugin marketplace add MageByte-Zero/spec-superflow --ref v1.0.0
 codex plugin add spec-superflow@spec-superflow
 
 # 升级并验证社区 marketplace 安装
@@ -169,9 +169,8 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v0.12.1`
-- v0.9.1 highlights：DP-4 执行模式推荐、跨 17 个平台的 portable runtime，以及无插件根路径的 raw-package smoke；详见 [CHANGELOG.md](CHANGELOG.md)
-- v0.9.0 highlights：支持 Node 20/22、model profiles 只读解析，以及 code-reviewer 的最小性审查
+- 当前版本：`v1.0.0`
+- v1.0：默认按风险走 Quick、direct Hotfix、Tweak 或 Full；小改动只保留边界与验证，复杂改动才进入完整规划、契约和审查
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)
 - 版本历史见 [CHANGELOG.md](CHANGELOG.md)
@@ -262,22 +261,21 @@ overlay，不会增加第九个状态；其 CLI 与 CodeBuddy/WorkBuddy Markdown
 
 ## 为什么需要它
 
-用 AI 写代码时，最常碰到两个失控点：
+用 AI 写代码时，最常见的两个问题是：
 
 - **还没想清楚要做什么，AI 就开始写代码。** 你说了句"帮我加个权限控制"，它就开始改几十个文件。改到一半才发现 —— 到底要 RBAC 还是 ABAC？
 
 - **规划文档写得明明白白，但执行阶段还是会跑偏。** proposal 写了、design 画了，但实现过程中没人盯着测试、没人卡 review，等到合并才发现行为不对。
 
-**spec-superflow 在这两个失控点之间建起一道硬墙：** 需求澄清 → 工件沉淀（Schema 引擎验证格式）→ 执行契约桥接 → TDD + SDD + Review Gate 三重纪律强制执行 → 验证收口 → delta spec 同步防止规范腐烂。
+spec-superflow 把这两类问题分开处理：先判断改动风险；小改动直接在明确边界内完成并验证，复杂改动再经过需求、规格、执行契约、实现和审查。这样既不让简单问题变成流程项目，也不让高风险改动跳过必要检查。
 
 | 设计原则 | 说明 |
 |---|---|
-| Spec First | 没有稳定的规划工件，不允许进入实现 |
-| Guarded Handoff | `execution-contract.md` 是规划到实现的唯一交接层 |
-| Strong Guardrails | 实现中违反契约的行为被明确拦截并回退 |
-| Schema Validated | 规划期工件经过 Schema 引擎验证 |
-| Execute Disciplined | TDD 铁律 + SDD 子代理驱动 + Review Gate |
-| Self-Contained | 不需要安装 OpenSpec 或 Superpowers，一个插件全包 |
+| 先选路径 | 根据文件数、边界和风险选择 Quick、Hotfix、Tweak 或 Full |
+| 复杂改动先对齐 | Full 路径用规格与执行契约确认范围和验收方式 |
+| 实现可验证 | 每条路径都要求与风险相称的测试或检查 |
+| 有问题先定位 | 遇到失败先复现和找根因，不连续试错 |
+| 自包含 | 不需要额外安装 OpenSpec 或 Superpowers |
 
 ### 适用场景
 
@@ -334,7 +332,7 @@ overlay，不会增加第九个状态；其 CLI 与 CodeBuddy/WorkBuddy Markdown
    closing            CLOSED 成功终态（无 next skill）
 ```
 
-**关键约束：** Full/legacy Hotfix 没有 `execution-contract.md`、current execution plan 或 `pass` review receipt → 不允许推进；Quick/direct Hotfix/Tweak 以有效 receipt、边界检查与 `test_result: pass` 放行。风险只触发建议与用户选择，绝不自动升级到 Full。
+**如何选择：** Quick、direct Hotfix、Tweak 默认保持轻量，只记录范围和验证；Full 与 legacy Hotfix 才要求执行契约、执行计划和 review receipt。风险会说明原因并交给用户选择，不会擅自升级路径。
 
 ### 快速路径（Quick / Hotfix / Tweak）
 

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -1,7 +1,7 @@
 <h1 align="center">spec-superflow</h1>
 
 <p align="center">
-  <strong>A self-contained AI coding workflow plugin fusing OpenSpec planning + Superpowers execution discipline</strong>
+  <strong>An AI coding workflow that uses lightweight or full controls based on change risk</strong>
 </p>
 
 <p align="center">
@@ -89,7 +89,7 @@ gemini extensions install https://github.com/MageByte-Zero/spec-superflow
 gemini extensions update spec-superflow   # upgrade
 ```
 
-### OpenCode / WorkBuddy / Trae
+### Other supported platforms
 
 | Platform | Method | Status |
 |----------|--------|--------|
@@ -97,8 +97,18 @@ gemini extensions update spec-superflow   # upgrade
 | **WorkBuddy** | `npx spec-superflow@latest install-workbuddy` | Installer provided |
 | **CodeBuddy Code CLI** | `ssf install-codebuddy` | Installer provided |
 | **Trae IDE / TRAE Work** | `.trae/skills/`, `~/.trae/skills/`, or zip/.skill upload | Manual/import |
+| **Cline** | `npx spec-superflow@latest install-cline` | Installer provided |
+| **Kiro** | `npx spec-superflow@latest install-kiro` | Installer provided |
+| **Windsurf** | `npx spec-superflow@latest install-windsurf` | Installer provided |
+| **Qwen Code** | `npx spec-superflow@latest install-qwen` | Installer provided |
+| **Amazon Q Developer** | `npx spec-superflow@latest install-amazon-q` | Installer provided |
+| **Roo Code** | `npx spec-superflow@latest install-roocode` | Installer provided |
+| **Continue** | `npx spec-superflow@latest install-continue` | Installer provided |
+| **Pi** | `npx spec-superflow@latest install-pi` | Installer provided |
+| **Qoder** | `npx spec-superflow@latest install-qoder` | Installer provided |
+| **ZCODE** | `ssf install-zcode` | Installer provided |
 
-> Full installation guide: [INSTALL.md](../INSTALL.md)
+> spec-superflow supports 19 platforms. See [INSTALL.md](../INSTALL.md) and the [platform matrix](platform-matrix.md) for the full matrix.
 
 ### CLI Toolchain
 
@@ -132,8 +142,8 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v0.12.1`
-- v0.9.1 highlights: DP-4 execution-mode recommendations, a portable runtime across 17 platforms, and a raw-package smoke with no plugin-root variable.
+- Current: `v1.0.0`
+- v1.0: Quick, direct Hotfix, Tweak, and Full paths keep small changes bounded while reserving planning, contracts, and reviews for complex work.
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)
 - Changelog: [CHANGELOG.md](../CHANGELOG.md)
@@ -183,22 +193,21 @@ In a **project that uses this plugin**, `changes/<change>/specs/` remains the ac
 
 ## Why
 
-AI coding sessions fail in one of two ways:
+AI coding sessions commonly fail in two ways:
 
 - **The AI starts coding before you've decided what to build.** You say "add authorization" and it touches 40 files before you realize — RBAC or ABAC?
 
 - **The plan is solid, but execution drifts.** The proposal, specs, and design are written, but nobody enforces testing, nobody gates reviews, and by merge time the behavior doesn't match.
 
-**spec-superflow builds a hard wall between these two failure points:** intent exploration → formal artifacts (Schema-validated) → execution contract bridge → TDD + SDD + Review Gate enforcement → verified closure → delta spec sync to prevent spec rot.
+spec-superflow handles these cases differently: it first assesses change risk; small changes stay within a clear boundary and verification step, while complex changes use intent, specs, an execution contract, implementation, and review. This keeps routine work short without skipping the checks that matter for risky work.
 
 | Principle | Meaning |
 |---|---|
-| Spec First | No stable planning artifacts → implementation blocked |
-| Guarded Handoff | `execution-contract.md` is the only bridge to implementation |
-| Strong Guardrails | Contract violations intercepted and rolled back |
-| Schema Validated | Planning artifacts validated by embedded engine |
-| Execute Disciplined | TDD Iron Law + SDD subagents + Review Gates |
-| Self-Contained | No external runtime dependencies |
+| Choose the path first | Select Quick, Hotfix, Tweak, or Full from scope and risk |
+| Align complex work | Full uses specs and an execution contract to agree scope and acceptance |
+| Verify implementation | Every path requires tests or checks proportionate to risk |
+| Diagnose before changing | Reproduce and locate failures before attempting a fix |
+| Self-contained | No OpenSpec or Superpowers runtime is required |
 
 ### When to Use
 
@@ -255,7 +264,7 @@ You: "add authorization to the API"
    closing            CLOSED successful terminal state (no next skill)
 ```
 
-**Hard constraints:** Full and legacy Hotfix require an approved `execution-contract.md`; Quick, direct Hotfix, and Tweak instead stay within their accepted boundary and persist `test_result: pass`. Requirements change mid-execution → forced rollback. Bug encountered → must enter debugging state, no ad-hoc fixes.
+**Path selection:** Quick, direct Hotfix, and Tweak remain lightweight: record the boundary and verification only. Full and legacy Hotfix require an execution contract, execution plan, and review receipt. Risks are explained for the user to choose from; they do not silently upgrade a path.
 
 ### Guarded execution plans
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v0.12.1: conditional injection — detects artifacts, injects workflow-start pointer
+# v1.0.0: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Four platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v0.12.1.
+Current version: v1.0.0.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "0.12.1",
+      "version": "1.0.0",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "0.12.1",
+  "version": "1.0.0",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/scripts/lib/cmd-version.mjs
+++ b/scripts/lib/cmd-version.mjs
@@ -18,16 +18,16 @@ const MANIFESTS = [
   { file: '.github/plugin/marketplace.json', path: ['plugins', '0', 'version'] },
 ];
 
-// ── Text files with regex patterns (first capture group = version to replace) ──
+// ── Text files with regex patterns (capture groups surround the version) ──
 // Note: CLAUDE.md is intentionally gitignored (project-local AI instructions).
 const TEXT_FILES = [
-  { file: 'README.md',              pattern: /(当前版本：`v?)0\.\d+\.\d+(`?)/g,                   replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: 'INSTALL.md',             pattern: /(当前发布版本：\*\*v)0\.\d+\.\d+(\*\*)/g,            replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: 'docs/README_en.md',      pattern: /(Current: `v)0\.\d+\.\d+(`)/g,                     replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: 'hooks/session-start',    pattern: /(# v)0\.\d+\.\d+(: conditional injection)/g,       replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: 'llms.txt',               pattern: /(Current version: v)0\.\d+\.\d+(\.)/g,             replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: '.claude/always/phase-guard.md', pattern: /(# spec-superflow v)0\.\d+\.\d+( \|)/g,      replacement: '$10.%MINOR%.%PATCH%$2' },
-  { file: 'GEMINI.md',              pattern: /(# spec-superflow v)0\.\d+\.\d+( \|)/g,              replacement: '$10.%MINOR%.%PATCH%$2' },
+  { file: 'README.md',              pattern: /(当前版本：`v?)\d+\.\d+\.\d+(`?)/g },
+  { file: 'INSTALL.md',             pattern: /(当前发布版本：\*\*v)\d+\.\d+\.\d+(\*\*)/g },
+  { file: 'docs/README_en.md',      pattern: /(Current: `v)\d+\.\d+\.\d+(`)/g },
+  { file: 'hooks/session-start',    pattern: /(# v)\d+\.\d+\.\d+(: conditional injection)/g },
+  { file: 'llms.txt',               pattern: /(Current version: v)\d+\.\d+\.\d+(\.)/g },
+  { file: '.claude/always/phase-guard.md', pattern: /(# spec-superflow v)\d+\.\d+\.\d+( \|)/g },
+  { file: 'GEMINI.md',              pattern: /(# spec-superflow v)\d+\.\d+\.\d+( \|)/g },
 ];
 
 function getNestedValue(obj, pathParts) {
@@ -62,7 +62,6 @@ export async function run(args) {
     console.error(`Invalid semver: ${newVersion}`);
     process.exit(2);
   }
-  const [, , minor, patch] = match;
 
   console.log(`Version sync → ${newVersion}${dryRun ? ' (dry run)' : ''}\n`);
   let changed = 0;
@@ -111,11 +110,10 @@ export async function run(args) {
     }
 
     const content = readFileSync(filePath, 'utf-8');
-    const replacement = entry.replacement
-      .replace('%MINOR%', minor)
-      .replace('%PATCH%', patch);
-
-    const newContent = content.replace(entry.pattern, replacement);
+    const newContent = content.replace(
+      entry.pattern,
+      (_match, prefix, suffix) => `${prefix}${newVersion}${suffix}`,
+    );
     if (newContent === content) {
       console.log(`  ✅ ${entry.file}: no version pattern matched (may already be correct)`);
       unchanged++;

--- a/tests/lib/marketplace-release-docs.test.mjs
+++ b/tests/lib/marketplace-release-docs.test.mjs
@@ -16,13 +16,12 @@ describe('marketplace release documentation', () => {
     }
   });
 
-  it('records v0.9.0 highlights and the external delivery gate', () => {
+  it('records v1.0 release guidance and the external delivery gate', () => {
     const readme = read('README.md');
     const checklist = read('docs/release-checklist.md');
-    assert.match(readme, /v0\.9\.0/);
+    assert.match(readme, /v1\.0\.0/);
+    assert.match(readme, /Quick、direct Hotfix、Tweak 或 Full/);
     assert.match(readme, /Node 20/);
-    assert.match(readme, /model profiles/);
-    assert.match(readme, /最小性/);
     assert.match(checklist, /AI Agent Marketplace Delivery/);
     assert.match(checklist, /verify-marketplace-release/);
     assert.match(checklist, /同步 PR/);

--- a/tests/lib/marketplace-release-docs.test.mjs
+++ b/tests/lib/marketplace-release-docs.test.mjs
@@ -21,7 +21,6 @@ describe('marketplace release documentation', () => {
     const checklist = read('docs/release-checklist.md');
     assert.match(readme, /v1\.0\.0/);
     assert.match(readme, /Quick、direct Hotfix、Tweak 或 Full/);
-    assert.match(readme, /Node 20/);
     assert.match(checklist, /AI Agent Marketplace Delivery/);
     assert.match(checklist, /verify-marketplace-release/);
     assert.match(checklist, /同步 PR/);

--- a/tests/lib/platform-runtime-distribution.test.mjs
+++ b/tests/lib/platform-runtime-distribution.test.mjs
@@ -174,7 +174,7 @@ describe('platform runtime inventory', () => {
 
 describe('runtime version synchronization', () => {
   it('does not version source runtime commands during a release dry-run', () => {
-    const output = execFileSync(process.execPath, [CLI, 'version', '0.9.2', '--dry-run'], {
+    const output = execFileSync(process.execPath, [CLI, 'version', '1.0.0', '--dry-run'], {
       cwd: ROOT,
       encoding: 'utf8',
     });
@@ -183,12 +183,17 @@ describe('runtime version synchronization', () => {
     assert.doesNotMatch(output, /skills\/build-executor\/implementer-prompt\.md: version string updated/);
     assert.doesNotMatch(output, /skills\/build-executor\/task-reviewer-prompt\.md: version string updated/);
     assert.doesNotMatch(output, /skills\/code-reviewer\/code-reviewer-prompt\.md: version string updated/);
+    assert.match(output, /README\.md: version string updated/);
+    assert.match(output, /INSTALL\.md: version string updated/);
+    assert.match(output, /hooks\/session-start: version string updated/);
   });
 
   it('updates npm lock metadata without rewriting source recovery commands', () => {
     const target = mkdtempSync(join(tmpdir(), 'ssf-version-release-assets-'));
     try {
       mkdirSync(join(target, 'commands', 'ssf'), { recursive: true });
+      mkdirSync(join(target, 'docs'), { recursive: true });
+      mkdirSync(join(target, 'hooks'), { recursive: true });
       writeFileSync(join(target, 'package.json'), '{"name":"fixture","version":"0.10.0"}\n');
       writeFileSync(join(target, 'package-lock.json'), `${JSON.stringify({
         name: 'fixture',
@@ -202,15 +207,25 @@ describe('runtime version synchronization', () => {
           `Run \`${SOURCE_RUNTIME_COMMAND} ${name}\`.\n`,
         );
       }
+      writeFileSync(join(target, 'README.md'), '当前版本：`v0.10.0`\n');
+      writeFileSync(join(target, 'INSTALL.md'), '当前发布版本：**v0.10.0**。\n');
+      writeFileSync(join(target, 'docs', 'README_en.md'), 'Current: `v0.10.0`\n');
+      writeFileSync(join(target, 'hooks', 'session-start'), '# v0.10.0: conditional injection\n');
+      writeFileSync(join(target, 'llms.txt'), 'Current version: v0.10.0.\n');
 
-      execFileSync(process.execPath, [CLI, 'version', '0.11.0'], {
+      execFileSync(process.execPath, [CLI, 'version', '1.0.0'], {
         cwd: target,
         encoding: 'utf8',
       });
 
       const lock = JSON.parse(readFileSync(join(target, 'package-lock.json'), 'utf8'));
-      assert.equal(lock.version, '0.11.0');
-      assert.equal(lock.packages[''].version, '0.11.0');
+      assert.equal(lock.version, '1.0.0');
+      assert.equal(lock.packages[''].version, '1.0.0');
+      assert.equal(readFileSync(join(target, 'README.md'), 'utf8'), '当前版本：`v1.0.0`\n');
+      assert.equal(readFileSync(join(target, 'INSTALL.md'), 'utf8'), '当前发布版本：**v1.0.0**。\n');
+      assert.equal(readFileSync(join(target, 'docs', 'README_en.md'), 'utf8'), 'Current: `v1.0.0`\n');
+      assert.equal(readFileSync(join(target, 'hooks', 'session-start'), 'utf8'), '# v1.0.0: conditional injection\n');
+      assert.equal(readFileSync(join(target, 'llms.txt'), 'utf8'), 'Current version: v1.0.0.\n');
       for (const name of ['resume', 'switch', 'save']) {
         assert.match(
           readFileSync(join(target, 'commands', 'ssf', `${name}.md`), 'utf8'),

--- a/tests/lib/platform-runtime-distribution.test.mjs
+++ b/tests/lib/platform-runtime-distribution.test.mjs
@@ -174,7 +174,7 @@ describe('platform runtime inventory', () => {
 
 describe('runtime version synchronization', () => {
   it('does not version source runtime commands during a release dry-run', () => {
-    const output = execFileSync(process.execPath, [CLI, 'version', '1.0.0', '--dry-run'], {
+    const output = execFileSync(process.execPath, [CLI, 'version', '2.0.0', '--dry-run'], {
       cwd: ROOT,
       encoding: 'utf8',
     });


### PR DESCRIPTION
## Summary
- prepare all manifests and runtime markers for v1.0.0
- refresh Chinese and English release/install guidance around the lightweight workflow
- fix `ssf version 1.0.0` so it preserves the major version

## Verification
- npm run build && npm test (653 passing)
- npm run validate
- npm run test:raw-mode
- ssf doctor
- recovery-command, WorkBuddy, and CodeBuddy smoke tests

## Release gate
The tag must wait for the external marketplace manifest to report 1.0.0.