### PR TITLE
release: prepare v1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "spec-superflow",
       "description": "8-state workflow engine with 9 collaborative skills. Bridges planning and execution via execution-contract.md. Embedded schema validation, TDD, SDD, code review, systematic debugging, and delta spec sync.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": "./",
       "author": {
         "name": "MageByte",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
   "source": "./",
   "author": {

--- a/.claude/always/phase-guard.md
+++ b/.claude/always/phase-guard.md
@@ -1,3 +1,3 @@
-# spec-superflow v1.0.0 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v1.0.1 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
   "author": {
     "name": "MageByte",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugin marketplace for Cursor",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "spec-superflow",
   "displayName": "spec-superflow",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline. 9 collaborative skills with embedded TDD, SDD, code review, debugging, and delta spec sync.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Spec-first workflow plugins and skills for AI coding agents.",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "spec-superflow",
       "description": "Spec-first workflow with planning artifacts, execution contracts, TDD, review gates, systematic debugging, and delta spec sync.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": ".",
       "author": {
         "name": "MageByte",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-08-10
+
 ### Fixed
 
 - **Evidence-backed DP-5 escalation (#102)**: replace raw `state set dp_5_*` writes with a guarded debugging-attempt ledger. `ssf debug attempt record/show` keeps failed fixes distinct from Wave Review repair failures, rejects duplicate or stale evidence, and `ssf debug escalate --confirm` requires at least three current attempts. Audit reports unsupported legacy DP-5 records instead of treating them as valid approvals.
+- **Bounded automatic repair retries (#105)**: stop formal review repair after three unresolved failures instead of five. Every implementer retry must carry new failure evidence, an updated focused brief, and a changed strategy; the third unresolved failure returns control for user adjudication rather than dispatching another subagent.
 
 ## [1.0.0] - 2026-08-03
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -8,7 +8,7 @@ The workflow is self-contained and does not require OpenSpec or Superpowers at r
 
 
 <!-- spec-superflow-phase-guard-start -->
-# spec-superflow v1.0.0 | 阶段: {{state}} | 工作流: {{workflow}}
+# spec-superflow v1.0.1 | 阶段: {{state}} | 工作流: {{workflow}}
 当前阶段允许的操作由 workflow-start 路由规则定义。
 禁止跨越 DP gate 进入下一阶段。变更范围以 execution-contract.md 的 Intent Lock 为准。
 <!-- spec-superflow-phase-guard-end -->

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,7 @@
 - [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) — 规划引擎（Schema 验证、Delta Spec、工件解析）
 - [obra/superpowers](https://github.com/obra/superpowers) — 执行纪律（TDD 铁律、SDD、系统化调试、代码审查）
 
-当前发布版本：**v1.0.0**。
+当前发布版本：**v1.0.1**。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ npx spec-superflow list          # 或通过 npx 使用
 
 ### 版本
 
-- 当前版本：`v1.0.0`
+- 当前版本：`v1.0.1`
 - v1.0：默认按风险走 Quick、direct Hotfix、Tweak 或 Full；小改动只保留边界与验证，复杂改动才进入完整规划、契约和审查
 - 自包含插件，不需要运行时安装 OpenSpec 或 Superpowers
 - 上游来源：[Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec) 和 [obra/superpowers](https://github.com/obra/superpowers)

--- a/docs/README_en.md
+++ b/docs/README_en.md
@@ -142,7 +142,7 @@ npm install -g spec-superflow
 
 ### Version
 
-- Current: `v1.0.0`
+- Current: `v1.0.1`
 - v1.0: Quick, direct Hotfix, Tweak, and Full paths keep small changes bounded while reserving planning, contracts, and reviews for complex work.
 - Self-contained — no OpenSpec or Superpowers runtime required
 - Upstream: [Fission-AI/OpenSpec](https://github.com/Fission-AI/OpenSpec), [obra/superpowers](https://github.com/obra/superpowers)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow plugin: clarified requirements → execution contract → disciplined implementation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# v1.0.0: conditional injection — detects artifacts, injects workflow-start pointer
+# v1.0.1: conditional injection — detects artifacts, injects workflow-start pointer
 msg="<EXTREMELY_IMPORTANT>\nYou have spec-superflow installed. Use /spec-superflow:workflow-start ONLY when you detect an active spec-superflow change in the workspace (look for \`.spec-superflow.yaml\`, \`proposal.md\`, \`execution-contract.md\`, or \`specs/\` directories), OR when the user explicitly invokes it by name. For ordinary coding tasks without spec-superflow artifacts, do NOT invoke workflow-start — just handle the request directly.\n</EXTREMELY_IMPORTANT>"
 
 # Four platforms share the same message, only output format differs.

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 ## Overview
 spec-superflow is a self-contained workflow integration plugin for Claude Code, Cursor, OpenAI Codex CLI/App, GitHub Copilot CLI, Gemini CLI, OpenCode, WorkBuddy, and Trae. It merges spec-driven planning artifacts (proposal, specs, design, tasks) with disciplined execution guardrails (TDD, review gates, controlled handoff) into one unified workflow.
 
-Current version: v1.0.0.
+Current version: v1.0.1.
 
 ## Key Documents
 - README.md: Chinese homepage with full usage guide and FAQ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spec-superflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spec-superflow",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "bin": {
         "spec-superflow": "scripts/spec-superflow.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-superflow",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Spec-first workflow: integrates OpenSpec planning engine + Superpowers execution discipline via bridge contract. 9 collaborative skills for multi-agent coding tools.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "spec-superflow",
   "description": "Spec-first workflow that bridges OpenSpec-style planning and Superpowers-style execution discipline.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "MageByte",
     "url": "https://github.com/MageByte-Zero"

--- a/scripts/lib/execution-plan.mjs
+++ b/scripts/lib/execution-plan.mjs
@@ -10,7 +10,7 @@ export const EXECUTION_MODES = ['inline', 'batch-inline', 'sdd'];
 
 const WAVE_STRATEGIES = new Set(['parallel', 'serial']);
 const REVIEW_STATUSES = new Set(['pass', 'fail']);
-const MAX_REPAIR_FAILURES = 5;
+const MAX_REPAIR_FAILURES = 3;
 const FULL_COMMIT_SHA = /^[0-9a-f]{40}$/i;
 const defaultGitRangeValidator = createGitRangeValidator();
 

--- a/skills/build-executor/SKILL.md
+++ b/skills/build-executor/SKILL.md
@@ -145,17 +145,14 @@ use the CLI-provided `waves[].repair` state together with `eligible` and
 `retryable`. The controller does not infer a repair round from filenames or
 history, and must not write, edit, or modify a repair-state file directly.
 
-- **Rounds 1–3 — recovery:** dispatch only the focused repair for the current
+- **Rounds 1–2 — recovery:** dispatch only the focused repair for the current
   wave. Give the implementer the CLI repair round, previous review report, and
   the prior review head. Generate a scoped diff from that head, then dispatch
   the `re-review-prompt.md` reviewer against the prior finding and that scoped
   diff. Do not redispatch dependent waves.
-- **Rounds 4–5 — escalation:** keep the same focused repair and scoped
-  re-review, but explicitly mark the dispatch as escalated and require the
-  report to explain why earlier recovery rounds did not resolve the finding.
-  The fifth unresolved receipt yields CLI status `adjudication-required`; stop
-  automatic dispatch and request a human adjudication rather than attempting a
-  sixth repair.
+- **Third unresolved failure — stop:** the third unresolved receipt yields CLI
+  status `adjudication-required`. Stop automatic dispatch and request a human
+  adjudication rather than attempting a fourth repair.
 - Every focused re-review still writes its separate persisted report and is
   recorded only through `ssf execution review <change-dir> --wave <id> --base
   <sha> --head <sha> --report .superpowers/sdd/reviews/<wave-id>-rereview.md --verdict <pass|fail>`.
@@ -163,7 +160,15 @@ history, and must not write, edit, or modify a repair-state file directly.
 
 ### Per-Task Loop
 1. **Dispatch implementer**: Load the template with `ssf runtime asset read skills/build-executor/implementer-prompt.md`. Extract task brief with `scripts/task-brief PLAN_FILE N`. Include: where task fits, brief path, interfaces from prior tasks, report file path.
-2. **Handle response**: DONE → generate review package + dispatch reviewer. DONE_WITH_CONCERNS → assess. NEEDS_CONTEXT → provide context. BLOCKED → re-dispatch with better model or escalate.
+2. **Handle response**: DONE → generate review package + dispatch reviewer.
+   DONE_WITH_CONCERNS → assess. For NEEDS_CONTEXT, BLOCKED, or another
+   unresolved failure, append `Task N: failed attempt X/3 — <reason>` to the
+   existing progress ledger. Retry only when the controller can name new
+   evidence, new context, or a specific strategy change. The retry brief contains
+   the prior failure reason, the single objective, and the necessary file paths;
+   do not repeat the planning pack or conversation history. After
+   the third unresolved failure, stop automatic dispatch, enter DP-5, and ask
+   the user for a decision.
 3. **Review**: Load `ssf runtime asset read skills/build-executor/task-reviewer-prompt.md`. Reviewer returns spec compliance + code quality verdicts with the wave ID, git range, report path, and `pass`/`fail` receipt command.
 4. **Fix**: If Critical or Important issues, write the `fail` receipt, read the
    CLI repair state, then dispatch only the focused repair and re-review path
@@ -210,7 +215,8 @@ This augments `.superpowers/sdd/progress.md`; it does not replace the progress
 ledger or add a new core workflow state. Do not claim a checkpoint is current
 when `ssf checkpoint list` reports it as stale.
 
-If task hits BLOCKED (3+ fix failures or changes outside declared scope), escalate to SDD.
+If a task reaches three unresolved failures, stop at DP-5 and request a human
+decision. If work moves outside the declared scope, replan instead of retrying.
 
 ## Tweak Mode
 

--- a/skills/build-executor/implementer-prompt.md
+++ b/skills/build-executor/implementer-prompt.md
@@ -32,9 +32,15 @@ Subagent (general-purpose):
     The controller supplies the CLI repair round, previous review report, prior
     review head, and the scoped repair range. Treat those as evidence and fix
     only the documented finding in that scoped diff. Do not edit receipt or
-    repair-state files, choose a new wave, or dispatch dependent work. For an
-    escalated repair round, explain in your report why the earlier recovery
-    rounds did not resolve the finding.
+    repair-state files, choose a new wave, or dispatch dependent work.
+
+    ## Retry Assignment (only when retrying an unresolved implementer task)
+
+    The controller supplies the failed-attempt count, prior failure reason, one
+    objective, and only the necessary file paths. Do not repeat an approach
+    unless it names new evidence, new context, or a specific strategy change.
+    After three unresolved failures, return BLOCKED for human adjudication
+    without editing.
 
     ## Before You Begin
 

--- a/skills/build-executor/re-review-prompt.md
+++ b/skills/build-executor/re-review-prompt.md
@@ -28,9 +28,9 @@ Subagent (general-purpose):
     declared repair scope. Do not re-run a broad review, modify the worktree,
     or edit receipt and repair-state files.
 
-    Rounds 1–3 are recovery rounds. Rounds 4–5 are escalation rounds: require
-    explicit evidence of why prior recovery did not resolve the finding. If the
-    CLI status is `adjudication-required`, do not request a sixth repair;
+    Rounds 1–2 are recovery rounds. The third unresolved failure opens the
+    circuit breaker. If the CLI status is `adjudication-required`, do not
+    request a fourth repair;
     document the unresolved issue for human adjudication.
 
     ## Output

--- a/skills/build-executor/task-reviewer-prompt.md
+++ b/skills/build-executor/task-reviewer-prompt.md
@@ -42,7 +42,7 @@ Subagent (general-purpose):
     Read the CLI-provided repair round, previous review report, and prior review
     head supplied by the controller. Review the scoped diff from that head, and
     decide whether it resolves the recorded finding without unrelated changes.
-    Do not inspect or alter receipt or repair-state files. A fifth unresolved
+    Do not inspect or alter receipt or repair-state files. A third unresolved
     review is `adjudication-required`, so report the unresolved evidence rather
     than requesting another automatic repair.
 

--- a/tests/lib/cmd-execution.test.mjs
+++ b/tests/lib/cmd-execution.test.mjs
@@ -646,16 +646,16 @@ describe('ssf execution', () => {
     assert.equal(shown.json.waves[1].eligible, true);
   });
 
-  it('shows a fifth unresolved repair as adjudication-required rather than dispatching another retry', () => {
+  it('shows a third unresolved repair as adjudication-required rather than dispatching another retry', () => {
     const planned = runSsf(['execution', 'plan', changeDir, '--mode', 'sdd',
-      '--reason', 'five failed repairs require a controller decision',
+      '--reason', 'three failed repairs require a controller decision',
       '--wave', 'wave-1:serial:1.1',
       '--wave', 'wave-2:serial:1.2:wave-1']);
     assert.equal(planned.exitCode, 0, planned.stderr);
 
     let base = gitRefs.base;
     let head = gitRefs.head;
-    for (let failure = 1; failure <= 5; failure += 1) {
+    for (let failure = 1; failure <= 3; failure += 1) {
       const failed = runSsf(['execution', 'review', changeDir, '--wave', 'wave-1',
         '--base', base, '--head', head,
         '--report', writeReviewReport(`adjudication-${failure}.md`), '--verdict', 'fail']);
@@ -667,7 +667,7 @@ describe('ssf execution', () => {
     const shown = runSsf(['execution', 'show', changeDir, '--json']);
     assert.equal(shown.exitCode, 0, shown.stderr);
     assert.equal(shown.json.waves[0].repair.status, 'adjudication-required');
-    assert.equal(shown.json.waves[0].repair.failure_count, 5);
+    assert.equal(shown.json.waves[0].repair.failure_count, 3);
     assert.equal(shown.json.waves[0].retryable, false);
     assert.equal(shown.json.waves[0].eligible, false);
     assert.equal(shown.json.waves[1].eligible, false);

--- a/tests/lib/execution-plan.test.mjs
+++ b/tests/lib/execution-plan.test.mjs
@@ -585,9 +585,9 @@ describe('execution plan data contract', () => {
     assert.match(wave.blockers.join('\n'), /content no longer matches/i);
   });
 
-  it('opens an adjudication circuit breaker after five unresolved review failures and blocks dependents', () => {
+  it('opens an adjudication circuit breaker after three unresolved review failures and blocks dependents', () => {
     const plan = createPlan(changeDir, {
-      mode: 'sdd', source: 'default', rationale: 'fifth failed repair requires adjudication',
+      mode: 'sdd', source: 'default', rationale: 'third failed repair requires adjudication',
       waves: [
         { id: 'wave-1', strategy: 'serial', tasks: ['1.1'], depends_on: [] },
         { id: 'wave-2', strategy: 'serial', tasks: ['1.2'], depends_on: ['wave-1'] },
@@ -597,7 +597,7 @@ describe('execution plan data contract', () => {
 
     let base = gitRefs.base;
     const head = gitRefs.head;
-    for (let failure = 1; failure <= 5; failure += 1) {
+    for (let failure = 1; failure <= 3; failure += 1) {
       recordReview(changeDir, 'wave-1', {
         status: 'fail', base, head, report: writeReviewReport(`failure-${failure}.md`),
       });
@@ -606,7 +606,7 @@ describe('execution plan data contract', () => {
 
     const [blocked, dependent] = describeWaves(changeDir, plan);
     assert.equal(blocked.repair.status, 'adjudication-required');
-    assert.equal(blocked.repair.failure_count, 5);
+    assert.equal(blocked.repair.failure_count, 3);
     assert.equal(blocked.retryable, false);
     assert.equal(blocked.eligible, false);
     assert.equal(dependent.eligible, false);

--- a/tests/lib/token-rules.test.mjs
+++ b/tests/lib/token-rules.test.mjs
@@ -129,12 +129,14 @@ describe('SDD focused re-review documentation contract', () => {
 
     assert.match(executor, /execution show <change-dir> --json[\s\S]*repair/i,
       'the controller must read CLI repair state before dispatching a repair');
-    assert.match(executor, /rounds? 1[–-]3[\s\S]*recovery/i,
-      'the first three failed reviews must remain focused recovery rounds');
-    assert.match(executor, /rounds? 4[–-]5[\s\S]*escalat/i,
-      'rounds four and five must be explicitly escalated');
+    assert.match(executor, /rounds? 1[–-]2[\s\S]*recovery/i,
+      'the first two failed reviews must remain focused recovery rounds');
     assert.match(executor, /adjudication-required/i,
-      'a fifth unresolved review must stop automatic dispatch for adjudication');
+      'a third unresolved review must stop automatic dispatch for adjudication');
+    assert.match(executor, /new evidence|new context|specific strategy change/i,
+      'an implementer retry must add concrete information instead of repeating the same attempt');
+    assert.match(executor, /prior failure reason[\s\S]*single objective[\s\S]*necessary file paths/i,
+      'retry context must stay focused instead of repeating the planning pack');
     assert.match(executor, /ssf execution review[\s\S]*--verdict <pass\|fail>/i,
       'every re-review must be persisted through the CLI receipt command');
     assert.doesNotMatch(executor, /(?:write|edit|modify) a repair-state file to (?:continue|resolve|record)/i,


### PR DESCRIPTION
## Summary

- bound automatic review and implementer repair at three unresolved failures
- require new evidence, context, or a strategy change before retrying, with a focused retry brief
- sync manifests, install docs, runtime markers, and changelog to v1.0.1
- keep the existing DP-5 debugging ledger unchanged; no new configuration or control layer

## Verification

- `npm run build`
- `npm test` — 669 passed, 0 failed
- `npm run validate`
- `npm run test:raw-mode`
- version consistency, doctor, recovery command assets
- WorkBuddy and CodeBuddy local-install smoke tests
- `npm pack --dry-run --json` — v1.0.1, 275 files, no local controller artifacts

## Release boundary

This PR prepares the source release only. It does not create a tag, publish npm, or create a GitHub Release. The external Codex marketplace must report v1.0.1 before the release tag is authorized.

Closes #105