### PR TITLE
feat: add cross-platform ssf command shim generation (path-shim)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format loosely follows Keep a Changelog.
 
 ## [Unreleased]
 
+### Added
+
+- **`ssf` command on CodeBuddy installs**: `ssf install-codebuddy` now generates `ssf` / `ssf.cmd` / `ssf.ps1` command shims under `~/.codebuddy/spec-superflow/bin/` and registers that `bin/` directory on the user PATH (idempotent, Windows user environment / POSIX shell rc files). After install, `ssf` is available in a new terminal just like a global npm install. `--no-path` skips the PATH change while still writing the shims. `ssf uninstall-codebuddy` removes the shims and the PATH entry.
+
+### Fixed
+
+- **CRLF-tolerant risk ownership matrix test**: `verification-risk-ownership.test.mjs` now normalizes line endings so the matrix parses identically on Windows (CRLF checkouts) and POSIX.
+
 ## [1.0.1] - 2026-08-10
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -408,6 +408,17 @@ CodeBuddy Code CLI 直接从 `~/.codebuddy/skills/` 读取 skill，从 `~/.codeb
 npx spec-superflow@latest install-codebuddy
 ```
 
+安装完成后，安装器会：
+
+- 在 `~/.codebuddy/spec-superflow/bin/` 生成 `ssf`（POSIX）、`ssf.cmd` / `ssf.ps1`（Windows）命令 shim，指向已部署的 `scripts/spec-superflow.mjs`；
+- 默认把 `bin/` 目录加入用户 PATH（幂等，重复安装不会产生重复条目），**新开终端**后即可像 `npm install -g spec-superflow` 一样直接使用 `ssf` 命令。
+
+如果不想修改用户 PATH，用 `--no-path` 跳过（shim 仍会生成，可手动把 `bin/` 加入 PATH）：
+
+```bash
+ssf install-codebuddy --no-path
+```
+
 本地仓库调试：
 
 ```bash
@@ -433,6 +444,7 @@ ssf install-codebuddy --config-dir /path/to/.codebuddy
 ├── spec-superflow/              ← pluginRoot（运行时依赖；${CLAUDE_PLUGIN_ROOT} 目标）
 │   ├── scripts/  docs/  templates/  dist/  hooks/
 │   │   └── session-start        ← 输出 hookSpecificOutput（CodeBuddy 分支）
+│   ├── bin/                     ← ssf 命令 shim（ssf / ssf.cmd / ssf.ps1，已加入用户 PATH）
 │   └── package.json
 ├── skills/                      ← 部署的 skill（路径已重写；其他 skill 保留）
 │   ├── workflow-start/
@@ -458,7 +470,7 @@ npx spec-superflow@latest install-codebuddy
 
 ### 卸载
 
-推荐使用专用卸载命令——它会从 `settings.json` 精确移除 spec-superflow 的 `SessionStart` 条目（保留其他 hook 与所有设置字段），并删除运行时目录、commands、phase-guard 规则与 9 个 skill 目录：
+推荐使用专用卸载命令——它会从 `settings.json` 精确移除 spec-superflow 的 `SessionStart` 条目（保留其他 hook 与所有设置字段），删除运行时目录（含 `bin/` 下的 ssf shim）、commands、phase-guard 规则与 9 个 skill 目录，并从用户 PATH 中移除 `~/.codebuddy/spec-superflow/bin` 条目（Windows 用户环境变量 / POSIX shell 配置文件；其他 PATH 条目保持不变）：
 
 ```bash
 ssf uninstall-codebuddy
@@ -481,7 +493,9 @@ ssf uninstall-codebuddy --config-dir /path/to/.codebuddy
 ### 验证
 
 ```bash
+ssf --version                                               # 新终端中应可执行（若已注册 PATH）
 ls ~/.codebuddy/skills/                                       # 应包含 9 个 spec-superflow skill
+ls ~/.codebuddy/spec-superflow/bin/                           # 应含 ssf / ssf.cmd / ssf.ps1
 ls ~/.codebuddy/spec-superflow/hooks/session-start            # hook 脚本存在
 cat ~/.codebuddy/settings.json | grep -A4 SessionStart        # SessionStart 指向 spec-superflow/hooks/session-start
 grep allowed-tools ~/.codebuddy/commands/ssf/resume.md        # 应为 Bash(node:*)（非 npx）

--- a/scripts/lib/cmd-install-codebuddy.mjs
+++ b/scripts/lib/cmd-install-codebuddy.mjs
@@ -39,6 +39,7 @@ import { parseArgs } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { shellQuote } from './shell-quote.mjs';
+import { writeShims, applyPathEntry } from './path-shim.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const defaultPluginRoot = resolve(__dirname, '..', '..'); // repo root when run from clone
@@ -415,6 +416,7 @@ function planInstall({ pluginRoot = defaultPluginRoot, configDir } = {}) {
   const version = readVersion(root);
   const pluginRootAbs = resolve(targetPluginDir);
   const sessionStartScript = join(pluginRootAbs, 'hooks', 'session-start');
+  const targetBinDir = join(targetPluginDir, 'bin');
 
   return {
     pluginRoot: root,
@@ -433,12 +435,13 @@ function planInstall({ pluginRoot = defaultPluginRoot, configDir } = {}) {
     version,
     pluginRootAbs,
     sessionStartScript,
+    targetBinDir,
   };
 }
 
 // ─── install ──────────────────────────────────────────────
 
-async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = {}) {
+async function installCodeBuddy({ pluginRoot, configDir, noPath = false, applyPath = applyPathEntry, plan: providedPlan } = {}) {
   const installPlan = providedPlan || planInstall({ pluginRoot, configDir });
   const {
     skillNames,
@@ -454,6 +457,7 @@ async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = 
     version,
     pluginRootAbs,
     sessionStartScript,
+    targetBinDir,
   } = installPlan;
 
   // 0. Clean old plugin runtime dir (runtime deps only; skills are managed separately).
@@ -507,6 +511,20 @@ async function installCodeBuddy({ pluginRoot, configDir, plan: providedPlan } = 
   await writeFile(settingsPath, JSON.stringify(mergedSettings, null, 2) + '\n', 'utf-8');
   console.log(`   settings.json → ${settingsPath} (SessionStart hook merged)`);
 
+  // 6. Generate the `ssf` command shims and register the bin dir on the user
+  //    PATH. This mirrors the npm global-install experience: after install,
+  //    `ssf` is available in any new shell. `--no-path` skips the PATH change
+  //    but still writes the shims so the command works with a manual PATH.
+  const binDir = await writeShims(pluginRootAbs);
+  console.log(`   bin/ → ${binDir} (ssf, ssf.cmd, ssf.ps1)`);
+  if (!noPath) {
+    const { applied, detail } = await applyPath({ binDir, action: 'add' });
+    console.log(`   PATH → ${detail}${applied ? '' : ' (already registered)'}`);
+    console.log(`   Next: open a new terminal for the PATH change to take effect; use --no-path to skip.`);
+  } else {
+    console.log(`   PATH → skipped (--no-path); shims remain at ${targetBinDir}`);
+  }
+
   return installPlan;
 }
 
@@ -520,6 +538,7 @@ export async function run(args) {
       'config-dir': { type: 'string' },
       tag: { type: 'string' },
       'dry-run': { type: 'boolean' },
+      'no-path': { type: 'boolean' },
     },
   });
 
@@ -539,6 +558,8 @@ export async function run(args) {
     console.log(`  Rules:       ${plan.targetRules}/phase-guard.md`);
     console.log(`  Commands:    ${plan.targetCommands}`);
     console.log(`  Settings:    ${plan.settingsPath} (SessionStart hook, merged)`);
+    console.log(`  Bin dir:     ${plan.targetBinDir} (ssf, ssf.cmd, ssf.ps1)`);
+    console.log(`  PATH:        ${values['no-path'] ? 'skip (--no-path)' : 'register bin dir on user PATH'}`);
     return;
   }
 
@@ -561,6 +582,7 @@ export async function run(args) {
     const plan = await installCodeBuddy({
       pluginRoot,
       configDir: values['config-dir'],
+      noPath: values['no-path'],
     });
 
     console.log(`\n✅ CodeBuddy install complete:`);
@@ -572,6 +594,8 @@ export async function run(args) {
     console.log(`   Skills dir:  ${plan.targetSkills}`);
     console.log(`   Rules:       ${plan.targetRules}/phase-guard.md`);
     console.log(`   Settings:    ${plan.settingsPath} (SessionStart hook merged)`);
+    console.log(`   Bin dir:     ${plan.targetBinDir} (ssf, ssf.cmd, ssf.ps1)`);
+    console.log(`   PATH:        ${values['no-path'] ? 'skipped (--no-path)' : 'registered on user PATH'}`);
     if (installedTag) {
       console.log(`   Version:     ${installedTag}`);
     }

--- a/scripts/lib/cmd-uninstall-codebuddy.mjs
+++ b/scripts/lib/cmd-uninstall-codebuddy.mjs
@@ -17,6 +17,7 @@ import { writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
+import { applyPathEntry } from './path-shim.mjs';
 
 const PLUGIN_NAME = 'spec-superflow';
 
@@ -89,6 +90,7 @@ function stripSsfHooks(input) {
 function planUninstall({ configDir } = {}) {
   const codebuddyRoot = getCodebuddyRoot(configDir);
   const targetPluginDir = join(codebuddyRoot, PLUGIN_NAME);
+  const targetBinDir = join(targetPluginDir, 'bin');
   const targetSkills = join(codebuddyRoot, 'skills');
   const targetCommands = join(codebuddyRoot, 'commands', 'ssf');
   const targetPhaseGuard = join(codebuddyRoot, 'rules', 'phase-guard.md');
@@ -96,6 +98,7 @@ function planUninstall({ configDir } = {}) {
   return {
     codebuddyRoot,
     targetPluginDir,
+    targetBinDir,
     targetSkills,
     targetCommands,
     targetPhaseGuard,
@@ -103,7 +106,7 @@ function planUninstall({ configDir } = {}) {
   };
 }
 
-export async function uninstallCodeBuddy({ configDir } = {}) {
+export async function uninstallCodeBuddy({ configDir, applyPath = applyPathEntry } = {}) {
   const plan = planUninstall({ configDir });
   const removed = [];
 
@@ -120,11 +123,17 @@ export async function uninstallCodeBuddy({ configDir } = {}) {
     }
   }
 
-  // 2. Remove runtime dir.
+  // 2. Remove runtime dir (includes bin/ shims).
   if (existsSync(plan.targetPluginDir)) {
     rmSync(plan.targetPluginDir, { recursive: true, force: true });
     removed.push(plan.targetPluginDir);
   }
+
+  // 2b. Remove the registered PATH entry for the bin dir. This must happen
+  //     even if the runtime dir no longer exists, so the stale PATH entry is
+  //     cleaned up. Other PATH entries are preserved.
+  const { applied } = await applyPath({ binDir: plan.targetBinDir, action: 'remove' });
+  if (applied) removed.push(`PATH entry (${plan.targetBinDir})`);
 
   // 3. Remove only the managed recovery command files (resume/save/switch.md).
   //    The shared ~/.codebuddy/commands/ssf/ directory may hold user-created
@@ -182,6 +191,8 @@ export async function run(args) {
     console.log(`  Config dir:  ${plan.codebuddyRoot}`);
     console.log(`  Settings:    ${plan.settingsPath} (strip spec-superflow SessionStart, keep rest)`);
     console.log(`  Runtime:     ${plan.targetPluginDir}`);
+    console.log(`  Bin dir:     ${plan.targetBinDir} (ssf shims)`);
+    console.log(`  PATH:        remove ${plan.targetBinDir} from user PATH (keep other entries)`);
     console.log(`  Commands:    ${plan.targetCommands}`);
     console.log(`  Phase guard: ${plan.targetPhaseGuard}`);
     console.log(`  Skills (${SPEC_SUPERFLOW_SKILLS.length}): ${SPEC_SUPERFLOW_SKILLS.join(', ')}`);

--- a/scripts/lib/path-shim.mjs
+++ b/scripts/lib/path-shim.mjs
@@ -1,0 +1,306 @@
+// scripts/lib/path-shim.mjs
+// Cross-platform user PATH management and `ssf` command shim generation for
+// the CodeBuddy installer.
+//
+// Goals:
+//   - Reproduce the npm global-install experience (a `ssf` command available
+//     in every shell) for `ssf install-codebuddy`.
+//   - PATH handling is split into pure functions (testable without touching
+//     the real environment) plus thin platform adapters (PowerShell on
+//     Windows, shell rc files on POSIX).
+//   - Idempotent: re-running the installer never duplicates PATH entries;
+//     the uninstaller removes exactly the entries it added.
+//
+// Deploy layout produced by this module:
+//   <codebuddyRoot>/spec-superflow/bin/
+//     ├── ssf        (POSIX shell shim)
+//     ├── ssf.cmd    (Windows CMD shim)
+//     └── ssf.ps1    (Windows PowerShell shim)
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { shellQuote } from './shell-quote.mjs';
+
+// ─── PATH pure functions ──────────────────────────────────
+//
+// These take explicit `platform`/`home` arguments so tests can exercise both
+// Windows and POSIX semantics on any host.
+
+/** Split a PATH string into non-empty entries. Windows uses ';', POSIX ':'. */
+export function splitPathEntries(pathString, platform = process.platform) {
+  if (!pathString) return [];
+  const sep = platform === 'win32' ? ';' : ':';
+  return pathString.split(sep).filter(entry => entry.length > 0);
+}
+
+/** Join PATH entries back into a PATH string. */
+export function joinPathEntries(entries, platform = process.platform) {
+  const sep = platform === 'win32' ? ';' : ':';
+  return entries.join(sep);
+}
+
+/**
+ * Normalize one PATH entry: trim, expand a leading `~`, and strip trailing
+ * path separators (keeping the filesystem root).
+ */
+export function normalizePathEntry(entry, home = homedir(), platform = process.platform) {
+  let p = typeof entry === 'string' ? entry.trim() : '';
+  if (!p) return p;
+  if (p === '~') {
+    p = home;
+  } else if (p.startsWith('~/') || (platform === 'win32' && p.startsWith('~\\'))) {
+    const sep = platform === 'win32' ? '\\' : '/';
+    p = home.replace(/[\\/]+$/, '') + sep + p.slice(2);
+  }
+  const root = platform === 'win32' ? /^[a-zA-Z]:[\\/]$/ : /^[\\/]$/;
+  while (p.length > 1 && (p.endsWith('/') || (platform === 'win32' && p.endsWith('\\')))) {
+    if (root.test(p)) break;
+    p = p.slice(0, -1);
+  }
+  return p;
+}
+
+/** Compare two PATH entries. Windows compares case-insensitively. */
+export function pathEntriesEqual(a, b, platform = process.platform) {
+  if (platform === 'win32') return a.toLowerCase() === b.toLowerCase();
+  return a === b;
+}
+
+/** Whether a PATH string already contains an entry equivalent to `target`. */
+export function pathContainsEntry(pathString, target, { platform = process.platform, home = homedir() } = {}) {
+  const norm = normalizePathEntry(target, home, platform);
+  return splitPathEntries(pathString, platform).some(entry =>
+    pathEntriesEqual(normalizePathEntry(entry, home, platform), norm, platform),
+  );
+}
+
+/**
+ * Add `target` to a PATH string if absent. Returns `{ path, added }`; never
+ * mutates the input, never duplicates.
+ */
+export function addPathEntry(pathString, target, { platform = process.platform, home = homedir() } = {}) {
+  if (pathContainsEntry(pathString, target, { platform, home })) {
+    return { path: pathString, added: false };
+  }
+  const norm = normalizePathEntry(target, home, platform);
+  const sep = platform === 'win32' ? ';' : ':';
+  const next = pathString && pathString.length > 0 ? `${pathString}${sep}${norm}` : norm;
+  return { path: next, added: true };
+}
+
+/** Remove every entry equivalent to `target` from a PATH string. */
+export function removePathEntry(pathString, target, { platform = process.platform, home = homedir() } = {}) {
+  const norm = normalizePathEntry(target, home, platform);
+  const entries = splitPathEntries(pathString, platform);
+  const kept = entries.filter(entry =>
+    !pathEntriesEqual(normalizePathEntry(entry, home, platform), norm, platform),
+  );
+  return { path: joinPathEntries(kept, platform), removed: kept.length < entries.length };
+}
+
+// ─── shim generation ──────────────────────────────────────
+
+/**
+ * Build the three `ssf` shim contents, each forwarding arguments to
+ * `node <pluginRoot>/scripts/spec-superflow.mjs`.
+ *
+ * @param {string} pluginRootAbs absolute plugin runtime root
+ * @returns {{ ssf: string, ssfCmd: string, ssfPs1: string }}
+ */
+export function shimContents(pluginRootAbs) {
+  const scriptPath = join(pluginRootAbs, 'scripts', 'spec-superflow.mjs');
+  // POSIX: single-quoted path (shellQuote escapes embedded quotes).
+  const posix = `exec node ${shellQuote(scriptPath)} "$@"`;
+  // Windows: double-quoted path survives cmd.exe and PowerShell.
+  const cmdPath = `"${scriptPath}"`;
+  return {
+    ssf: `#!/bin/sh\n# spec-superflow ssf launcher (generated by ssf install-codebuddy)\n${posix}\n`,
+    ssfCmd: `@ECHO off\r\nREM spec-superflow ssf launcher (generated by ssf install-codebuddy)\r\nnode ${cmdPath} %*\r\n`,
+    ssfPs1: `# spec-superflow ssf launcher (generated by ssf install-codebuddy)\nnode ${cmdPath} $args\n`,
+  };
+}
+
+/**
+ * Write the three shims into `<pluginRootAbs>/bin/`. Returns the bin dir.
+ */
+export async function writeShims(pluginRootAbs) {
+  const binDir = join(pluginRootAbs, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  const contents = shimContents(pluginRootAbs);
+  await writeFile(join(binDir, 'ssf'), contents.ssf, { encoding: 'utf-8', mode: 0o755 });
+  await writeFile(join(binDir, 'ssf.cmd'), contents.ssfCmd, 'utf-8');
+  await writeFile(join(binDir, 'ssf.ps1'), contents.ssfPs1, 'utf-8');
+  return binDir;
+}
+
+// ─── shell profile detection (POSIX) ──────────────────────
+
+/**
+ * Resolve the rc file for the user's default shell.
+ * Returns null on Windows (PATH lives in the user registry environment).
+ */
+export function detectShellConfigPath(home, shell, platform = process.platform) {
+  if (platform === 'win32') return null;
+  const name = (shell || '').split('/').pop() || '';
+  if (name.includes('zsh')) return join(home, '.zshrc');
+  if (name.includes('bash')) return join(home, '.bashrc');
+  if (name.includes('fish')) return join(home, '.config', 'fish', 'config.fish');
+  // POSIX sh, unknown shells, or an unset $SHELL (GUI-launched terminals).
+  return join(home, '.profile');
+}
+
+/** Regex-escape a literal string for use inside a RegExp. */
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Whether `shell` resolves to fish (the only shell using `set -gx` syntax). */
+function isFishShell(shell) {
+  const name = (shell || '').split('/').pop() || '';
+  return name.includes('fish');
+}
+
+/** Escape a path for embedding inside a fish double-quoted string. */
+function escapeFishDoubleQuoted(value) {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\$/g, '\\$');
+}
+
+/**
+ * The exact PATH-management line this module manages for a bin dir.
+ * Fish uses `set -gx PATH "<binDir>" $PATH`; bash/zsh use `export PATH="<binDir>:$PATH"`.
+ *
+ * @param {string} binDir normalized bin directory
+ * @param {string} [shell] default shell, used to pick the line syntax
+ * @returns {string}
+ */
+export function posixExportLine(binDir, shell = process.env.SHELL) {
+  if (isFishShell(shell)) {
+    return `set -gx PATH "${escapeFishDoubleQuoted(binDir)}" $PATH`;
+  }
+  return `export PATH="${binDir}:$PATH"`;
+}
+
+/**
+ * Build a matcher for the exact managed line (tolerating quote variants),
+ * anchored to the whole line so unrelated lines are never touched.
+ */
+function managedLineMatcher(norm, shell) {
+  if (isFishShell(shell)) {
+    return new RegExp(`^set\\s+-gx\\s+PATH\\s+["']?${escapeRegExp(escapeFishDoubleQuoted(norm))}["']?\\s+\\$PATH\\s*$`);
+  }
+  return new RegExp(`^\\s*export\\s+PATH\\s*=\\s*["']${escapeRegExp(norm)}:\\$PATH["']\\s*$`);
+}
+
+/**
+ * Append the managed PATH line (bash/zsh `export`, fish `set -gx`) to an rc
+ * file. Idempotent: returns false (and writes nothing) when the exact line
+ * already exists in any quoting variant. Creates the file when missing.
+ */
+export function addPosixExportLine(rcPath, binDir, { home = homedir(), shell = process.env.SHELL } = {}) {
+  const norm = normalizePathEntry(binDir, home, 'linux');
+  const existing = existsSync(rcPath) ? readFileSync(rcPath, 'utf-8') : '';
+  const matcher = managedLineMatcher(norm, shell);
+  if (existing.split('\n').some(line => matcher.test(line))) return false;
+  const line = `${posixExportLine(norm, shell)}\n`;
+  const next = existing.endsWith('\n') || existing === '' ? existing + line : existing + '\n' + line;
+  mkdirSync(dirname(rcPath), { recursive: true });
+  writeFileSync(rcPath, next, 'utf-8');
+  return true;
+}
+
+/**
+ * Remove the managed PATH line(s) for a bin dir from an rc file. Only the
+ * exact managed line (any quoting variant) is removed; every other line is
+ * preserved. Returns true when something was removed.
+ */
+export function removePosixExportLine(rcPath, binDir, { home = homedir(), shell = process.env.SHELL } = {}) {
+  if (!existsSync(rcPath)) return false;
+  const norm = normalizePathEntry(binDir, home, 'linux');
+  const lines = readFileSync(rcPath, 'utf-8').split('\n');
+  const matcher = managedLineMatcher(norm, shell);
+  const kept = lines.filter(line => !matcher.test(line));
+  if (kept.length === lines.length) return false;
+  writeFileSync(rcPath, kept.join('\n'), 'utf-8');
+  return true;
+}
+
+// ─── user PATH adapters (Windows) ─────────────────────────
+
+/** Default PowerShell executor used on Windows. Injectable for tests. */
+export function powershellExec(script) {
+  return execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    { encoding: 'utf-8' },
+  ).trim();
+}
+
+/** Read the user-level PATH (HKCU\Environment). */
+export async function readWindowsUserPath(executor = powershellExec) {
+  return executor("[Environment]::GetEnvironmentVariable('Path','User')");
+}
+
+/** Write the user-level PATH (HKCU\Environment). */
+export async function writeWindowsUserPath(value, executor = powershellExec) {
+  const quoted = JSON.stringify(value);
+  executor(`[Environment]::SetEnvironmentVariable('Path', ${quoted}, 'User')`);
+}
+
+// ─── unified apply / remove ───────────────────────────────
+
+/**
+ * Apply (add or remove) a PATH entry at the user level for the current
+ * platform. Options are injectable so tests can exercise every branch.
+ *
+ * @param {Object} opts
+ * @param {string} opts.binDir        directory to register (e.g. .../bin)
+ * @param {'add'|'remove'} [opts.action]
+ * @param {string} [opts.home]
+ * @param {string} [opts.shell]       default shell (POSIX detection)
+ * @param {string} [opts.platform]
+ * @param {boolean} [opts.dryRun]     report intent without writing
+ * @param {Function} [opts.readWindowsUserPath]
+ * @param {Function} [opts.writeWindowsUserPath]
+ * @returns {Promise<{applied: boolean, detail: string}>}
+ */
+export async function applyPathEntry({
+  binDir,
+  action = 'add',
+  home = homedir(),
+  shell = process.env.SHELL,
+  platform = process.platform,
+  dryRun = false,
+  readWindowsUserPath: readWin = readWindowsUserPath,
+  writeWindowsUserPath: writeWin = writeWindowsUserPath,
+} = {}) {
+  const norm = normalizePathEntry(binDir, home, platform);
+
+  if (platform === 'win32') {
+    const current = await readWin();
+    const result = action === 'add'
+      ? addPathEntry(current, norm, { platform: 'win32', home })
+      : removePathEntry(current, norm, { platform: 'win32', home });
+    if (!dryRun && (result.added || result.removed)) {
+      await writeWin(result.path);
+    }
+    return {
+      applied: Boolean(result.added || result.removed),
+      detail: `user PATH (Windows): ${result.added ? 'added' : result.removed ? 'removed' : 'unchanged'} ${norm}`,
+    };
+  }
+
+  const rcPath = detectShellConfigPath(home, shell, platform);
+  if (!rcPath) {
+    return { applied: false, detail: `no PATH target for platform ${platform}` };
+  }
+  const applied = action === 'add'
+    ? (!dryRun && addPosixExportLine(rcPath, norm, { home, shell }))
+    : (!dryRun && removePosixExportLine(rcPath, norm, { home, shell }));
+  return {
+    applied,
+    detail: `${action === 'add' ? 'added' : 'removed'} PATH entry for ${norm} in ${rcPath}`,
+  };
+}

--- a/specs/codebuddy-ssf-path/spec.md
+++ b/specs/codebuddy-ssf-path/spec.md
@@ -1,0 +1,104 @@
+# codebuddy-ssf-path
+
+## Purpose
+
+The codebuddy-ssf-path capability documents the published behavior for users and maintainers.
+
+## Requirements
+
+### Requirement: 跨平台生成 ssf 命令 shim
+
+CodeBuddy 安装器 SHALL 在 `<codebuddyRoot>/spec-superflow/bin/` 目录下生成 `ssf` 命令 shim，其可执行行为等价于 `node <pluginRoot>/scripts/spec-superflow.mjs <args...>`，其中 `<pluginRoot>` 是已部署的插件运行时目录。
+
+shim 文件集合取决于目标平台：
+
+- POSIX（Linux / macOS）SHALL 生成一个无扩展名的可执行文件 `ssf`，内容为 `#!/bin/sh` 起始的 shell 脚本，通过 `exec node "<pluginRoot>/scripts/spec-superflow.mjs" "$@"` 转发全部参数。
+- Windows SHALL 生成 `ssf.cmd`（CMD 批处理）与 `ssf.ps1`（PowerShell）两个 shim，分别以 `node "<pluginRoot>/scripts/spec-superflow.mjs" %*` 与 `node "<pluginRoot>/scripts/spec-superflow.mjs" $args` 转发全部参数。
+
+shim 内容中的 `<pluginRoot>` SHALL 以绝对路径形式内嵌，且 SHALL 对含空格与特殊字符的路径做正确引用（quoted），保证在 Git Bash、CMD、PowerShell 中均可直接执行。
+
+#### Scenario: POSIX 平台安装生成 shell shim
+
+- **WHEN** 在 Linux 或 macOS 上安装 CodeBuddy 插件
+- **THEN** `<codebuddyRoot>/spec-superflow/bin/ssf` 存在、可执行（含 shebang `#!/bin/sh`），其内容通过 `node` 调用部署的 `spec-superflow.mjs`
+
+#### Scenario: Windows 平台安装生成 CMD 与 PowerShell shim
+
+- **WHEN** 在 Windows 上安装 CodeBuddy 插件
+- **THEN** `<codebuddyRoot>/spec-superflow/bin/ssf.cmd` 与 `<codebuddyRoot>/spec-superflow/bin/ssf.ps1` 均存在，且通过 `node` 调用部署的 `spec-superflow.mjs`
+
+#### Scenario: 路径含空格时 shim 仍可执行
+
+- **WHEN** `<codebuddyRoot>` 的路径包含空格（如 `C:\Users\John Doe\.codebuddy`）
+- **THEN** 生成的 shim 中对 `<pluginRoot>` 的引用被正确加引号，执行 `ssf --version` 不报路径解析错误
+
+### Requirement: 将 bin 目录注册到用户 PATH（幂等）
+
+CodeBuddy 安装器 SHALL 将 `<codebuddyRoot>/spec-superflow/bin` 注册到当前用户的 PATH 环境变量中，并且 SHALL 保证重复安装不产生重复的 PATH 条目（幂等）。
+
+PATH 注册的跨平台策略：
+
+- Windows SHALL 通过用户级环境变量（`HKCU\Environment`）写入，不得使用 `setx`（其 1024 字符截断风险），不得写入系统级 PATH。
+- POSIX SHALL 向用户默认 shell 的配置文件追加 `export PATH="<binDir>:$PATH"` 行：bash 使用 `~/.bashrc`，zsh 使用 `~/.zshrc`；当默认 shell 无法识别时回退到 `~/.profile`。
+
+当安装命令带 `--no-path` 选项时，安装器 SHALL NOT 修改用户的 PATH 环境变量，但仍 SHALL 生成 shim 文件。
+
+#### Scenario: 首次安装注册 PATH
+
+- **WHEN** 用户首次安装且 PATH 中不存在该 bin 目录
+- **THEN** 用户 PATH 中出现 `<codebuddyRoot>/spec-superflow/bin` 条目，且该条目唯一
+
+#### Scenario: 重复安装不重复注册
+
+- **WHEN** 用户重复运行安装器且 PATH 中已存在该 bin 目录
+- **THEN** PATH 中该目录条目数不增加（保持 1 条）
+
+#### Scenario: --no-path 跳过 PATH 修改
+
+- **WHEN** 用户以 `--no-path` 运行安装器
+- **THEN** 用户 PATH 保持不变，但 `<codebuddyRoot>/spec-superflow/bin/` 下的 shim 仍被生成
+
+#### Scenario: Windows 用户级 PATH 写入
+
+- **WHEN** 在 Windows 上安装且未带 `--no-path`
+- **THEN** PATH 修改发生在用户级环境变量（`HKCU\Environment`），系统级 PATH 未被修改
+
+#### Scenario: POSIX shell 配置文件追加
+
+- **WHEN** 在 Linux 或 macOS 上安装且未带 `--no-path`
+- **THEN** 检测到的 shell 配置文件（`~/.bashrc` / `~/.zshrc` / `~/.profile`）中追加了一行 `export PATH="<binDir>:$PATH"`，且重复安装不产生重复行
+
+### Requirement: 卸载时清理 shim 与 PATH 条目
+
+CodeBuddy 卸载器 SHALL 在卸载时删除 `<codebuddyRoot>/spec-superflow/bin/` 目录（含全部 shim），并 SHALL 从用户 PATH 中移除该目录条目（Windows 用户级 PATH 移除该条目；POSIX 从 shell 配置文件中移除对应 export 行）。
+
+卸载器 SHALL NOT 修改或删除 PATH 中的其他条目，SHALL NOT 删除用户 shell 配置文件中的其他内容。
+
+#### Scenario: 卸载后 PATH 不含 bin 目录
+
+- **WHEN** 用户运行卸载器且此前已注册 PATH
+- **THEN** 用户 PATH 中不再出现 `<codebuddyRoot>/spec-superflow/bin` 条目，其他 PATH 条目保持不变
+
+#### Scenario: 卸载删除 shim 目录
+
+- **WHEN** 用户运行卸载器
+- **THEN** `<codebuddyRoot>/spec-superflow/bin/` 目录被删除
+
+#### Scenario: 卸载不影响其他 PATH 条目与配置文件内容
+
+- **WHEN** 用户运行卸载器且用户 PATH 中含有其他自建条目、shell 配置文件中含有其他用户内容
+- **THEN** 其他 PATH 条目与 shell 配置文件中的其他内容均保持不变
+
+### Requirement: install-codebuddy 命令支持 --no-path 选项
+
+`ssf install-codebuddy` 命令 SHALL 新增 `--no-path` 布尔选项。默认（不带该选项）行为为生成 shim 并注册 PATH；带 `--no-path` 时仅生成 shim、不注册 PATH。`--dry-run` 模式 SHALL 在计划输出中显示是否将注册 PATH 及目标 bin 目录。
+
+#### Scenario: 默认安装输出与行为
+
+- **WHEN** 用户不带 `--no-path` 运行 `ssf install-codebuddy`
+- **THEN** 安装输出包含 bin 目录路径与 PATH 注册信息，且用户 PATH 被更新
+
+#### Scenario: dry-run 展示 PATH 计划
+
+- **WHEN** 用户以 `--dry-run` 运行 `ssf install-codebuddy`
+- **THEN** 计划输出包含 bin 目录路径与 PATH 注册说明，且不实际修改任何文件或环境变量

--- a/tests/lib/cmd-install-codebuddy.test.mjs
+++ b/tests/lib/cmd-install-codebuddy.test.mjs
@@ -17,6 +17,10 @@ async function loadModule(relPath) {
 let tempDir;
 let planInstall, installCodeBuddy, planUninstall, uninstallCodeBuddy;
 
+// The install/uninstall flow may call applyPathEntry to mutate the real user
+// PATH; tests must inject a no-op so the host environment is never touched.
+const noopApplyPath = async ({ action }) => ({ applied: false, detail: `${action}: no-op (test)` });
+
 describe('cmd-install-codebuddy', () => {
   beforeEach(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'ssf-codebuddy-'));
@@ -70,7 +74,7 @@ describe('cmd-install-codebuddy', () => {
   it('deploys skills, runtime, rules, and merges SessionStart into settings.json', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     // skills
     assert.ok(existsSync(join(configDir, 'skills', 'workflow-start', 'SKILL.md')));
@@ -95,10 +99,60 @@ describe('cmd-install-codebuddy', () => {
     assert.ok(!existsSync(join(configDir, 'hooks', 'hooks.json')));
   });
 
+  it('generates ssf command shims in the bin dir on install', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
+
+    const binDir = join(configDir, 'spec-superflow', 'bin');
+    const posixShim = readFileSync(join(binDir, 'ssf'), 'utf-8');
+    assert.ok(posixShim.startsWith('#!/bin/sh'));
+    assert.match(posixShim, /exec node .+spec-superflow\.mjs/);
+    assert.match(posixShim, /\$@/);
+
+    const cmdShim = readFileSync(join(binDir, 'ssf.cmd'), 'utf-8');
+    assert.ok(cmdShim.startsWith('@ECHO off'));
+    assert.match(cmdShim, /node .+spec-superflow\.mjs/);
+    assert.match(cmdShim, /%*/);
+
+    const psShim = readFileSync(join(binDir, 'ssf.ps1'), 'utf-8');
+    assert.match(psShim, /node .+spec-superflow\.mjs/);
+    assert.match(psShim, /\$args/);
+  });
+
+  it('registers the bin dir on PATH by default and skips with --no-path', async () => {
+    const pluginRoot = makePluginRoot();
+    const calls = [];
+    const recordingApplyPath = async (opts) => {
+      calls.push(opts);
+      return { applied: true, detail: 'recorded' };
+    };
+
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: recordingApplyPath });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].action, 'add');
+    assert.equal(calls[0].binDir, join(configDir, 'spec-superflow', 'bin'));
+
+    // --no-path: shims are written but applyPath is never invoked.
+    const configDir2 = join(tempDir, 'cb2');
+    await installCodeBuddy({ pluginRoot, configDir: configDir2, noPath: true, applyPath: recordingApplyPath });
+    assert.equal(calls.length, 1, '--no-path must not call applyPath');
+    assert.ok(existsSync(join(configDir2, 'spec-superflow', 'bin', 'ssf.cmd')), 'shims still written with --no-path');
+  });
+
+  it('run --dry-run writes nothing to disk', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb-dry');
+    const mod = await loadModule('scripts/lib/cmd-install-codebuddy.mjs');
+    await mod.run(['--dry-run', '--local', pluginRoot, '--config-dir', configDir]);
+    assert.ok(!existsSync(configDir), 'dry-run must not create the config dir');
+  });
+
   it('rewrites --local recovery commands to use the deployed local runtime', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     for (const name of ['resume', 'save', 'switch']) {
       const content = readFileSync(join(configDir, 'commands', 'ssf', `${name}.md`), 'utf-8');
@@ -116,7 +170,7 @@ describe('cmd-install-codebuddy', () => {
   it('rewrites npx invocations in deployed skills to use the local runtime', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
     const skillMd = readFileSync(join(configDir, 'skills', 'workflow-start', 'SKILL.md'), 'utf-8');
     // Source SKILL.md used npx --yes --package spec-superflow@0.12.1 ssf; deployed must use node <pluginRoot>/scripts/spec-superflow.mjs
     assert.doesNotMatch(skillMd, /npx --yes --package spec-superflow@\d+\.\d+\.\d+ ssf/);
@@ -137,7 +191,7 @@ describe('cmd-install-codebuddy', () => {
     };
     writeFileSync(join(configDir, 'settings.json'), JSON.stringify(existing, null, 2));
 
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8'));
     // other top-level fields preserved
@@ -164,7 +218,7 @@ describe('cmd-install-codebuddy', () => {
     mkdirSync(join(skillsDir, 'other-skill'), { recursive: true });
     writeFileSync(join(skillsDir, 'other-skill', 'SKILL.md'), '---\nname: other-skill\n---\n');
 
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     assert.ok(existsSync(join(skillsDir, 'other-skill', 'SKILL.md')), 'other skill preserved');
     assert.ok(existsSync(join(skillsDir, 'workflow-start', 'SKILL.md')), 'ssf skill deployed');
@@ -173,8 +227,8 @@ describe('cmd-install-codebuddy', () => {
   it('re-running install upgrades in place without duplicating SessionStart', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     const settings = JSON.parse(readFileSync(join(configDir, 'settings.json'), 'utf-8'));
     const ssfEntries = settings.hooks.SessionStart.filter(e =>
@@ -256,7 +310,7 @@ describe('cmd-uninstall-codebuddy', () => {
   it('removes only spec-superflow artifacts and preserves other settings/hooks/skills', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     // Seed unrelated skill, rule, and SessionStart hook + settings field.
     const skillsDir = join(configDir, 'skills');
@@ -270,7 +324,7 @@ describe('cmd-uninstall-codebuddy', () => {
     settings.enabledPlugins = { 'other@market': true };
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
 
-    const { removed } = await uninstallCodeBuddy({ configDir });
+    const { removed } = await uninstallCodeBuddy({ configDir, applyPath: noopApplyPath });
     assert.ok(removed.length > 0);
 
     // spec-superflow artifacts gone
@@ -299,14 +353,14 @@ describe('cmd-uninstall-codebuddy', () => {
   it('preserves user-created commands/ssf/custom.md and only removes managed files', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
 
     // Seed a user-created command in the shared commands/ssf/ directory.
     const ssfCommandsDir = join(configDir, 'commands', 'ssf');
     mkdirSync(ssfCommandsDir, { recursive: true });
     writeFileSync(join(ssfCommandsDir, 'custom.md'), '---\ndescription: user command\n---\nbody\n');
 
-    await uninstallCodeBuddy({ configDir });
+    await uninstallCodeBuddy({ configDir, applyPath: noopApplyPath });
 
     // Managed files removed
     assert.ok(!existsSync(join(ssfCommandsDir, 'resume.md')), 'resume.md removed');
@@ -322,8 +376,8 @@ describe('cmd-uninstall-codebuddy', () => {
     const allSkills = ['workflow-start','build-executor','code-reviewer','contract-builder','need-explorer','release-archivist','spec-merger','spec-writer','bug-investigator'];
     const pluginRoot = makePluginRoot({ skills: allSkills });
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
-    await uninstallCodeBuddy({ configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
+    await uninstallCodeBuddy({ configDir, applyPath: noopApplyPath });
     for (const name of allSkills) {
       assert.ok(!existsSync(join(configDir, 'skills', name)), `${name} skill removed`);
     }
@@ -331,14 +385,33 @@ describe('cmd-uninstall-codebuddy', () => {
 
   it('is safe when nothing is installed', async () => {
     const configDir = join(tempDir, 'empty-cb');
-    const { removed } = await uninstallCodeBuddy({ configDir });
+    const { removed } = await uninstallCodeBuddy({ configDir, applyPath: noopApplyPath });
     assert.equal(removed.length, 0);
+  });
+
+  it('removes the PATH entry on uninstall', async () => {
+    const pluginRoot = makePluginRoot();
+    const configDir = join(tempDir, 'cb');
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
+
+    const calls = [];
+    const recordingApplyPath = async (opts) => {
+      calls.push(opts);
+      return { applied: true, detail: 'recorded' };
+    };
+    await uninstallCodeBuddy({ configDir, applyPath: recordingApplyPath });
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].action, 'remove');
+    assert.equal(calls[0].binDir, join(configDir, 'spec-superflow', 'bin'));
+    // runtime dir (incl. bin/ shims) gone
+    assert.ok(!existsSync(join(configDir, 'spec-superflow')));
   });
 
   it('run --dry-run writes nothing', async () => {
     const pluginRoot = makePluginRoot();
     const configDir = join(tempDir, 'cb');
-    await installCodeBuddy({ pluginRoot, configDir });
+    await installCodeBuddy({ pluginRoot, configDir, applyPath: noopApplyPath });
     const mod = await loadModule('scripts/lib/cmd-uninstall-codebuddy.mjs');
     await mod.run(['--dry-run', '--config-dir', configDir]);
     assert.ok(existsSync(join(configDir, 'spec-superflow')), 'dry-run must not delete artifacts');

--- a/tests/lib/path-shim.test.mjs
+++ b/tests/lib/path-shim.test.mjs
@@ -1,0 +1,393 @@
+// tests/lib/path-shim.test.mjs
+// Tests for scripts/lib/path-shim.mjs — cross-platform PATH management and
+// ssf command shim generation for the CodeBuddy installer.
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+
+// Windows-safe dynamic import: bare Windows paths (D:\...) are not valid ESM
+// import specifiers, so convert to a file:// URL. No-op on POSIX.
+async function loadModule(relPath) {
+  return import(pathToFileURL(join(process.cwd(), relPath)).href);
+}
+
+let tempDir;
+
+describe('path-shim PATH pure functions', () => {
+  let pathShim;
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'ssf-pathshim-'));
+    pathShim = await loadModule('scripts/lib/path-shim.mjs');
+  });
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('splitPathEntries', () => {
+    it('splits POSIX PATH on colon', () => {
+      assert.deepEqual(
+        pathShim.splitPathEntries('/usr/bin:/bin:/opt/tools', 'linux'),
+        ['/usr/bin', '/bin', '/opt/tools'],
+      );
+    });
+
+    it('splits Windows PATH on semicolon', () => {
+      assert.deepEqual(
+        pathShim.splitPathEntries('C:\\Windows;C:\\bin;C:\\tools', 'win32'),
+        ['C:\\Windows', 'C:\\bin', 'C:\\tools'],
+      );
+    });
+
+    it('returns empty array for empty or falsy input', () => {
+      assert.deepEqual(pathShim.splitPathEntries('', 'linux'), []);
+      assert.deepEqual(pathShim.splitPathEntries(null, 'linux'), []);
+    });
+
+    it('drops empty entries between separators', () => {
+      assert.deepEqual(pathShim.splitPathEntries('/a::/b:', 'linux'), ['/a', '/b']);
+    });
+  });
+
+  describe('normalizePathEntry', () => {
+    it('expands ~ to home dir', () => {
+      assert.equal(
+        pathShim.normalizePathEntry('~/bin', '/home/tester', 'linux'),
+        '/home/tester/bin',
+      );
+    });
+
+    it('strips trailing separator but keeps root', () => {
+      assert.equal(pathShim.normalizePathEntry('/opt/tools/', '/home/tester', 'linux'), '/opt/tools');
+      assert.equal(pathShim.normalizePathEntry('/', '/home/tester', 'linux'), '/');
+    });
+
+    it('strips trailing backslash on Windows', () => {
+      assert.equal(pathShim.normalizePathEntry('C:\\tools\\', 'C:\\Users\\tester', 'win32'), 'C:\\tools');
+    });
+
+    it('keeps plain paths unchanged', () => {
+      assert.equal(pathShim.normalizePathEntry('/usr/local/bin', '/home/tester', 'linux'), '/usr/local/bin');
+    });
+  });
+
+  describe('pathEntriesEqual', () => {
+    it('is case-insensitive on Windows', () => {
+      assert.equal(pathShim.pathEntriesEqual('c:\\tools', 'C:\\Tools', 'win32'), true);
+    });
+
+    it('is case-sensitive on POSIX', () => {
+      assert.equal(pathShim.pathEntriesEqual('/opt/Tools', '/opt/tools', 'linux'), false);
+    });
+  });
+
+  describe('addPathEntry (idempotent)', () => {
+    it('adds an entry when missing', () => {
+      const r = pathShim.addPathEntry('/usr/bin:/bin', '/opt/tools', { platform: 'linux', home: '/home/tester' });
+      assert.equal(r.added, true);
+      assert.equal(r.path, '/usr/bin:/bin:/opt/tools');
+    });
+
+    it('does not duplicate an existing entry', () => {
+      const r = pathShim.addPathEntry('/usr/bin:/opt/tools:/bin', '/opt/tools', { platform: 'linux', home: '/home/tester' });
+      assert.equal(r.added, false);
+      assert.equal(r.path, '/usr/bin:/opt/tools:/bin');
+    });
+
+    it('is case-insensitive on Windows', () => {
+      const r = pathShim.addPathEntry('C:\\Windows;C:\\tools', 'c:\\Tools', { platform: 'win32', home: 'C:\\Users\\tester' });
+      assert.equal(r.added, false);
+    });
+
+    it('handles empty existing PATH', () => {
+      const r = pathShim.addPathEntry('', '/opt/tools', { platform: 'linux', home: '/home/tester' });
+      assert.equal(r.added, true);
+      assert.equal(r.path, '/opt/tools');
+    });
+  });
+
+  describe('removePathEntry', () => {
+    it('removes a matching entry and keeps others', () => {
+      const r = pathShim.removePathEntry('/usr/bin:/opt/tools:/bin', '/opt/tools', { platform: 'linux', home: '/home/tester' });
+      assert.equal(r.removed, true);
+      assert.equal(r.path, '/usr/bin:/bin');
+    });
+
+    it('reports removed=false when entry is absent', () => {
+      const r = pathShim.removePathEntry('/usr/bin:/bin', '/opt/tools', { platform: 'linux', home: '/home/tester' });
+      assert.equal(r.removed, false);
+      assert.equal(r.path, '/usr/bin:/bin');
+    });
+
+    it('removes all duplicates of the target', () => {
+      const r = pathShim.removePathEntry('/opt/tools:/usr/bin:/opt/tools', '/opt/tools', { platform: 'linux', home: '/home/tester' });
+      assert.equal(r.removed, true);
+      assert.equal(r.path, '/usr/bin');
+    });
+  });
+
+  describe('shimContents', () => {
+    // On Windows the host join() emits backslashes even for a POSIX-looking
+    // input, so assert with a platform-neutral separator class [\\/].
+    const SCRIPT_RE = /spec-superflow[\\/]+scripts[\\/]+spec-superflow\.mjs/;
+
+    it('generates POSIX shim with shebang and exec node forwarding', () => {
+      const { ssf } = pathShim.shimContents('/home/tester/.codebuddy/spec-superflow');
+      assert.ok(ssf.startsWith('#!/bin/sh'));
+      assert.match(ssf, new RegExp(`exec node .+${SCRIPT_RE.source}`));
+      assert.match(ssf, /\$@/);
+    });
+
+    it('generates Windows cmd shim with @ECHO off and %* forwarding', () => {
+      const { ssfCmd } = pathShim.shimContents('C:\\Users\\tester\\.codebuddy\\spec-superflow');
+      assert.ok(ssfCmd.startsWith('@ECHO off'));
+      assert.match(ssfCmd, new RegExp(`node .+${SCRIPT_RE.source}`));
+      assert.match(ssfCmd, /%\*/);
+    });
+
+    it('generates PowerShell shim with $args forwarding', () => {
+      const { ssfPs1 } = pathShim.shimContents('C:\\Users\\tester\\.codebuddy\\spec-superflow');
+      assert.match(ssfPs1, new RegExp(`node .+${SCRIPT_RE.source}`));
+      assert.match(ssfPs1, /\$args/);
+    });
+
+    it('quotes paths containing spaces', () => {
+      const { ssf } = pathShim.shimContents('/home/John Doe/.codebuddy/spec-superflow');
+      assert.match(ssf, /['"][^'"]*John Doe[^'"]*['"]/);
+      const { ssfCmd } = pathShim.shimContents('C:\\Users\\John Doe\\.codebuddy\\spec-superflow');
+      assert.match(ssfCmd, /"[^"]*John Doe[^"]*"/);
+    });
+  });
+
+  describe('detectShellConfigPath', () => {
+    it('maps zsh to .zshrc', () => {
+      assert.equal(
+        pathShim.detectShellConfigPath('/home/tester', '/bin/zsh', 'linux'),
+        join('/home/tester', '.zshrc'),
+      );
+    });
+
+    it('maps bash to .bashrc', () => {
+      assert.equal(
+        pathShim.detectShellConfigPath('/home/tester', '/bin/bash', 'linux'),
+        join('/home/tester', '.bashrc'),
+      );
+    });
+
+    it('maps fish to config.fish', () => {
+      assert.equal(
+        pathShim.detectShellConfigPath('/home/tester', '/usr/bin/fish', 'linux'),
+        join('/home/tester', '.config', 'fish', 'config.fish'),
+      );
+    });
+
+    it('falls back to .profile when shell is unknown or empty', () => {
+      assert.equal(
+        pathShim.detectShellConfigPath('/home/tester', '', 'linux'),
+        join('/home/tester', '.profile'),
+      );
+      assert.equal(
+        pathShim.detectShellConfigPath('/home/tester', '/usr/bin/tcsh', 'linux'),
+        join('/home/tester', '.profile'),
+      );
+    });
+
+    it('returns null on Windows (registry-based PATH)', () => {
+      assert.equal(pathShim.detectShellConfigPath('C:\\Users\\tester', 'C:\\Program Files\\Git\\bin\\bash.exe', 'win32'), null);
+    });
+  });
+
+  describe('posix rc file line management', () => {
+    it('adds an export line and stays idempotent', () => {
+      const rc = join(tempDir, '.bashrc');
+      writeFileSync(rc, '# existing\n');
+      const r1 = pathShim.addPosixExportLine(rc, '/home/tester/.codebuddy/spec-superflow/bin', { home: '/home/tester', shell: '/bin/bash' });
+      assert.equal(r1, true);
+      const content1 = readFileSync(rc, 'utf-8');
+      assert.match(content1, /export PATH="\/home\/tester\/\.codebuddy\/spec-superflow\/bin:\$PATH"/);
+      assert.ok(content1.includes('# existing'));
+
+      const r2 = pathShim.addPosixExportLine(rc, '/home/tester/.codebuddy/spec-superflow/bin', { home: '/home/tester', shell: '/bin/bash' });
+      assert.equal(r2, false, 'second add must be a no-op');
+      const content2 = readFileSync(rc, 'utf-8');
+      assert.equal(content1, content2, 'file must not change on re-add');
+    });
+
+    it('creates the rc file when missing', () => {
+      const rc = join(tempDir, '.zshrc');
+      const added = pathShim.addPosixExportLine(rc, '/home/tester/bin', { home: '/home/tester', shell: '/bin/bash' });
+      assert.equal(added, true);
+      assert.ok(existsSync(rc));
+    });
+
+    it('removes only the matching export line', () => {
+      const rc = join(tempDir, '.bashrc');
+      writeFileSync(
+        rc,
+        '# keep me\nexport PATH="/home/tester/.codebuddy/spec-superflow/bin:$PATH"\nexport PATH="/usr/bin:$PATH"\n',
+      );
+      const removed = pathShim.removePosixExportLine(rc, '/home/tester/.codebuddy/spec-superflow/bin', { home: '/home/tester', shell: '/bin/bash' });
+      assert.equal(removed, true);
+      const content = readFileSync(rc, 'utf-8');
+      assert.ok(content.includes('# keep me'));
+      assert.ok(content.includes('export PATH="/usr/bin:$PATH"'));
+      assert.doesNotMatch(content, /spec-superflow\/bin/);
+    });
+
+    it('reports removed=false when no matching line exists', () => {
+      const rc = join(tempDir, '.bashrc');
+      writeFileSync(rc, 'export PATH="/usr/bin:$PATH"\n');
+      const removed = pathShim.removePosixExportLine(rc, '/home/tester/.codebuddy/spec-superflow/bin', { home: '/home/tester', shell: '/bin/bash' });
+      assert.equal(removed, false);
+      assert.equal(readFileSync(rc, 'utf-8'), 'export PATH="/usr/bin:$PATH"\n');
+    });
+
+    it('writes fish set -gx syntax and removes only that line', () => {
+      const rc = join(tempDir, '.config', 'fish', 'config.fish');
+      const binDir = join(tempDir, '.codebuddy', 'spec-superflow', 'bin');
+      const shell = '/usr/bin/fish';
+
+      const added = pathShim.addPosixExportLine(rc, binDir, { home: tempDir, shell });
+      assert.equal(added, true);
+      const content1 = readFileSync(rc, 'utf-8');
+      assert.match(content1, /set -gx PATH ".+bin" \$PATH/);
+      assert.doesNotMatch(content1, /export PATH/);
+
+      const again = pathShim.addPosixExportLine(rc, binDir, { home: tempDir, shell });
+      assert.equal(again, false, 'fish add must be idempotent');
+      assert.equal(readFileSync(rc, 'utf-8'), content1, 'fish file must not change on re-add');
+
+      const removed = pathShim.removePosixExportLine(rc, binDir, { home: tempDir, shell });
+      assert.equal(removed, true);
+      assert.doesNotMatch(readFileSync(rc, 'utf-8'), /spec-superflow/);
+    });
+
+    it('escapes fish-quoted binDir containing spaces or quotes', () => {
+      assert.equal(
+        pathShim.posixExportLine('/home/John Doe/bin', '/usr/bin/fish'),
+        'set -gx PATH "/home/John Doe/bin" $PATH',
+      );
+      assert.equal(
+        pathShim.posixExportLine('/home/Jo"hn/bin', '/usr/bin/fish'),
+        'set -gx PATH "/home/Jo\\"hn/bin" $PATH',
+      );
+      // bash/zsh keep the export syntax regardless of path content
+      assert.equal(
+        pathShim.posixExportLine('/home/tester/bin', '/bin/bash'),
+        'export PATH="/home/tester/bin:$PATH"',
+      );
+    });
+  });
+
+  describe('applyPathEntry', () => {
+    it('adds a POSIX export line and removes it again', async () => {
+      const home = tempDir;
+      const result = await pathShim.applyPathEntry({
+        binDir: join(home, '.codebuddy', 'spec-superflow', 'bin'),
+        action: 'add',
+        home,
+        shell: '/bin/bash',
+        platform: 'linux',
+      });
+      assert.equal(result.applied, true);
+      const rc = join(home, '.bashrc');
+      assert.ok(existsSync(rc));
+      // On Windows the temp home path uses backslashes; assert platform-neutral.
+      assert.match(readFileSync(rc, 'utf-8'), /export PATH=".+bin:\$PATH"/);
+
+      const removed = await pathShim.applyPathEntry({
+        binDir: join(home, '.codebuddy', 'spec-superflow', 'bin'),
+        action: 'remove',
+        home,
+        shell: '/bin/bash',
+        platform: 'linux',
+      });
+      assert.equal(removed.applied, true);
+      assert.doesNotMatch(readFileSync(rc, 'utf-8'), /spec-superflow/);
+    });
+
+    it('dryRun reports intent without writing', async () => {
+      const home = tempDir;
+      const result = await pathShim.applyPathEntry({
+        binDir: join(home, '.codebuddy', 'spec-superflow', 'bin'),
+        action: 'add',
+        home,
+        shell: '/bin/zsh',
+        platform: 'linux',
+        dryRun: true,
+      });
+      assert.equal(result.applied, false, 'dryRun must not write');
+      assert.ok(!existsSync(join(home, '.zshrc')), 'dryRun must not create the rc file');
+    });
+
+    it('adds a fish set -gx line and removes it again', async () => {
+      const home = tempDir;
+      const result = await pathShim.applyPathEntry({
+        binDir: join(home, '.codebuddy', 'spec-superflow', 'bin'),
+        action: 'add',
+        home,
+        shell: '/usr/bin/fish',
+        platform: 'linux',
+      });
+      assert.equal(result.applied, true);
+      const rc = join(home, '.config', 'fish', 'config.fish');
+      assert.ok(existsSync(rc));
+      assert.match(readFileSync(rc, 'utf-8'), /set -gx PATH ".+bin" \$PATH/);
+
+      const removed = await pathShim.applyPathEntry({
+        binDir: join(home, '.codebuddy', 'spec-superflow', 'bin'),
+        action: 'remove',
+        home,
+        shell: '/usr/bin/fish',
+        platform: 'linux',
+      });
+      assert.equal(removed.applied, true);
+      assert.doesNotMatch(readFileSync(rc, 'utf-8'), /spec-superflow/);
+    });
+
+    it('updates the Windows user PATH via injected executor', async () => {
+      let writtenValue = null;
+      const readWin = async () => 'C:\\Windows;C:\\tools';
+      const writeWin = async (value) => { writtenValue = value; };
+
+      const result = await pathShim.applyPathEntry({
+        binDir: 'C:\\Users\\tester\\.codebuddy\\spec-superflow\\bin',
+        action: 'add',
+        home: 'C:\\Users\\tester',
+        platform: 'win32',
+        readWindowsUserPath: readWin,
+        writeWindowsUserPath: writeWin,
+      });
+      assert.equal(result.applied, true);
+      assert.equal(writtenValue, 'C:\\Windows;C:\\tools;C:\\Users\\tester\\.codebuddy\\spec-superflow\\bin');
+
+      // Idempotent: adding again writes nothing.
+      writtenValue = null;
+      const again = await pathShim.applyPathEntry({
+        binDir: 'C:\\Users\\tester\\.codebuddy\\spec-superflow\\bin',
+        action: 'add',
+        home: 'C:\\Users\\tester',
+        platform: 'win32',
+        readWindowsUserPath: async () => writtenValue || 'C:\\Windows;C:\\tools;C:\\Users\\tester\\.codebuddy\\spec-superflow\\bin',
+        writeWindowsUserPath: writeWin,
+      });
+      assert.equal(again.applied, false);
+      assert.equal(writtenValue, null, 'no write on idempotent add');
+
+      // Remove keeps other entries.
+      writtenValue = null;
+      const removed = await pathShim.applyPathEntry({
+        binDir: 'C:\\Users\\tester\\.codebuddy\\spec-superflow\\bin',
+        action: 'remove',
+        home: 'C:\\Users\\tester',
+        platform: 'win32',
+        readWindowsUserPath: async () => 'C:\\Windows;C:\\tools;C:\\Users\\tester\\.codebuddy\\spec-superflow\\bin',
+        writeWindowsUserPath: writeWin,
+      });
+      assert.equal(removed.applied, true);
+      assert.equal(writtenValue, 'C:\\Windows;C:\\tools');
+    });
+  });
+});

--- a/tests/lib/state-loader.test.mjs
+++ b/tests/lib/state-loader.test.mjs
@@ -5,6 +5,7 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
 
 let tempDir;
 
@@ -14,7 +15,9 @@ describe('state-loader: readState()', () => {
   before(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'ssf-state-test-'));
     const modulePath = join(process.cwd(), 'scripts/lib/state-loader.mjs');
-    stateLoader = await import(modulePath);
+    // Windows-safe dynamic import: bare Windows paths (D:\...) are not valid
+    // ESM import specifiers, so convert to a file:// URL.
+    stateLoader = await import(pathToFileURL(modulePath).href);
   });
 
   after(() => {
@@ -118,7 +121,9 @@ describe('state-loader: writeState()', () => {
   before(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'ssf-state-write-'));
     const modulePath = join(process.cwd(), 'scripts/lib/state-loader.mjs');
-    stateLoader = await import(modulePath);
+    // Windows-safe dynamic import: bare Windows paths (D:\...) are not valid
+    // ESM import specifiers, so convert to a file:// URL.
+    stateLoader = await import(pathToFileURL(modulePath).href);
   });
 
   after(() => {
@@ -224,7 +229,9 @@ describe('state-loader: updateField()', () => {
   before(async () => {
     tempDir = mkdtempSync(join(tmpdir(), 'ssf-state-update-'));
     const modulePath = join(process.cwd(), 'scripts/lib/state-loader.mjs');
-    stateLoader = await import(modulePath);
+    // Windows-safe dynamic import: bare Windows paths (D:\...) are not valid
+    // ESM import specifiers, so convert to a file:// URL.
+    stateLoader = await import(pathToFileURL(modulePath).href);
   });
 
   after(() => {

--- a/tests/lib/verification-risk-ownership.test.mjs
+++ b/tests/lib/verification-risk-ownership.test.mjs
@@ -15,7 +15,8 @@ const REQUIRED_COLUMNS = [
 describe('verification risk ownership matrix', () => {
   it('names one end-to-end owner and a fast contract for every migrated repeated risk', () => {
     assert.equal(existsSync(MATRIX_PATH), true, 'risk ownership matrix must be available as a curated public example');
-    const lines = readFileSync(MATRIX_PATH, 'utf8').split('\n').filter(line => line.startsWith('|'));
+    // Normalize CRLF so the matrix parses identically on Windows and POSIX.
+    const lines = readFileSync(MATRIX_PATH, 'utf8').replace(/\r/g, '').split('\n').filter(line => line.startsWith('|'));
     assert.deepEqual(lines[0].split('|').filter(Boolean).map(value => value.trim()), REQUIRED_COLUMNS);
 
     const rows = lines.slice(2).map(line => line.split('|').filter(Boolean).map(value => value.trim()));


### PR DESCRIPTION
## What

新增跨平台 PATH 管理与 `ssf` 命令 shim 生成模块：

- `scripts/lib/path-shim.mjs`：跨平台 PATH 读取/写入（Windows/macOS/Linux），支持幂等注册与移除
- `cmd-install-codebuddy`：生成 `ssf` / `ssf.cmd` / `ssf.ps1` 三平台 shim 并注册用户 PATH（幂等，`--no-path` 可跳过）
- `cmd-uninstall-codebuddy`：同步移除 shim 文件与 PATH 条目
- 新增 `specs/codebuddy-ssf-path/spec.md` 规格文档与 path-shim / install 测试
- 修复 `verification-risk-ownership` 测试的 CRLF 容错
- 更新 `CHANGELOG.md` 与 `INSTALL.md`

## Test

`npm run build && npm test` 通过。